### PR TITLE
Removed warning suppressor

### DIFF
--- a/emperor.cabal
+++ b/emperor.cabal
@@ -54,11 +54,10 @@ executable emperor
   main-is:             Main.hs
   
   -- Compiler flags
-  ghc-options:         -Wall -Wextra -Werror -O2 -Wno-unused-imports
-                       --  TODO: Fix the unused imports warning
+  ghc-options:         -Wall -Wextra -Werror -O2
 
   -- Source directories
-  hs-source-dirs:      ., ./parser/, ./logging/, ./formatter/
+  hs-source-dirs:      ., ./formatter/, ./logging/, ./parser/, ./type-checking/
   
   -- Modules included in this executable, other than Main.
   -- other-modules:       
@@ -69,7 +68,8 @@ executable emperor
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.9 && <4.10,
                        array >= 0.5.1.1,
-                       ansi-terminal >= 0.9.1
+                       ansi-terminal >= 0.9.1,
+                       containers >= 0.5.7
   
   -- Directories containing source files.
   -- hs-source-dirs:      

--- a/parser/EmperorLexer.x
+++ b/parser/EmperorLexer.x
@@ -1,4 +1,5 @@
 {
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 {-|
 Module      : EmperorLexer
 Description : Lexer for the emperor language
@@ -12,8 +13,6 @@ Language    : Haskell2010
 This module defines the machinery to lexically analyse the Emperor language given in an input string.
 -}
 module EmperorLexer (Alex, Token(..), lexWrap, alexError, runAlex, AlexPosn) where
-
-import AST
 }
 
 %wrapper "monad"


### PR DESCRIPTION
### Problem description

Despite all warnings being activated and converted in to errors in `emperor.cabal`, `-Wno-unused-imports` was required to ensure that generated lexer files do not cause errors when parts following a `LINE` pragma reference another file.
I.e. although an import is used in a file on disk, it is not considered used once the compiler is directed to consider content of this file as if it were from another.
This file-fragment then does not use the specified import, thereby causing a `unused-imports` warning to be generated.

### How this PR fixes the problem

This removes the `-Wno-unused-imports` suppressor flag from the cabal file and places it in a pragma at the top of the lexer spec.

### Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

It would be nice to fix this in future but this at lease localises the problem to somewhere where it is less of an issue.
