### PR TITLE
Context free

### DIFF
--- a/examples/testProgram.e
+++ b/examples/testProgram.e
@@ -1,15 +1,18 @@
 /*
  * Some documentation?
 */
-helloWorld = 43;
-// fdsa=234
+helloWorld = 43
+a = 2
+// fdsa=
 fhdasjkl   \
- = 4321;
-with asdf = 3;
+ = 4321
+with asdf = 3:
 	a = @print(2);
-for a <- bs;
-	b <- @print('a');
-	@print(3);
+#
+for a <- bs:
+	b <- @print('a')
+	@print(3)
+	while true:
+		@print('y')
+##
 sadf <- pure(fdsa);
-;
-;

--- a/formatter/Formatter.hs
+++ b/formatter/Formatter.hs
@@ -10,7 +10,7 @@ Language    : Haskell2010
 
 This file defines the standard format for all Emperor programs.
 -}
-module Formatter where
+module Formatter (Format, FormatContext, formatFresh, format) where
 
 import AST
 import Data.List

--- a/formatter/Formatter.hs
+++ b/formatter/Formatter.hs
@@ -42,7 +42,7 @@ instance Format AST where
 
 -- | Doclines may be formatted as they appear
 instance Format DocLines where
-    format ctx (DocLines ds) = unlines $ [indent ctx ++ "/*"] ++ (format ctx <$> ds) ++ [indent ctx ++ "*/"] 
+    format ctx (DocLines ds) = makeLines $ [indent ctx ++ "/*"] ++ (format ctx <$> ds) ++ [indent ctx ++ "*/"] 
 
 -- | Doclines are formatted as comments
 instance Format DocLine where
@@ -51,12 +51,12 @@ instance Format DocLine where
 -- | Body block may be formatted with included code indented one layer further
 instance Format BodyBlock where
     format ctx (Line l)         = format ctx l
-    format ctx (IfElse c b1 b2) = unlines $ [ indent ctx ++ "if " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> b1) ++ [indent ctx ++ "else"] ++ (format (ctx + 1) <$> b2) 
-    format ctx (While c b)      = unlines $ [ indent ctx ++ "while " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> b)
-    format ctx (For i e b)      = unlines $ [ indent ctx ++ "for " ++ format (ctx + 1) i ++ " <- " ++ format (ctx + 1) e] ++ (format (ctx + 1) <$> b)
-    format ctx (Repeat c b)     = unlines $ [ indent ctx ++ "repeat " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> b)
-    format ctx (With a b)       = unlines $ [ indent ctx ++ "with " ++ format (ctx + 1) a] ++ (format (ctx + 1) <$> b)
-    format ctx (Switch c s)     = unlines $ [ indent ctx ++ "switch " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> s)
+    format ctx (IfElse c b1 b2) = makeLines $ [ indent ctx ++ "if " ++ format (ctx + 1) c ++ ":"] ++ (format (ctx + 1) <$> b1) ++ [indent ctx ++ "#"] ++ [indent ctx ++ "else"] ++ (format (ctx + 1) <$> b2) 
+    format ctx (While c b)      = makeLines $ [ indent ctx ++ "while " ++ format (ctx + 1) c ++ ":"] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
+    format ctx (For i e b)      = makeLines $ [ indent ctx ++ "for " ++ format (ctx + 1) i ++ " <- " ++ format (ctx + 1) e ++ ":"] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
+    format ctx (Repeat c b)     = makeLines $ [ indent ctx ++ "repeat " ++ format (ctx + 1) c ++ ":"] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
+    format ctx (With a b)       = makeLines $ [ indent ctx ++ "with " ++ format (ctx + 1) a ++ ":"] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
+    format ctx (Switch c s)     = makeLines $ [ indent ctx ++ "switch " ++ format (ctx + 1) c ++ ":"] ++ (format (ctx + 1) <$> s) ++ [indent ctx ++ "#"]
 
 -- | Switch-cases may be formatted with their case contents
 instance Format SwitchCase where
@@ -142,3 +142,11 @@ instance Format Tabs where
 -- | Create the appropriate amount of indentation for the current context
 indent :: FormatContext -> String
 indent ctx = replicate ctx '\t'
+
+makeLines :: [String] -> String
+makeLines xs = concat $ makeLines' xs
+    where
+        makeLines' :: [String] -> [String]
+        makeLines' [] = []
+        makeLines' (x:[]) = [x]
+        makeLines' (x:xs') = x : "\n" : makeLines' xs'

--- a/parser/EmperorParser.hs.patch
+++ b/parser/EmperorParser.hs.patch
@@ -1,6 +1,6 @@
---- ./EmperorParser.hs.orig	2019-07-24 01:14:14.674868234 +0100
-+++ ./EmperorParser.hs	2019-07-24 01:14:14.682868329 +0100
-@@ -833,6 +833,7 @@
+--- ./parser/EmperorParser.hs.orig	2019-07-24 12:44:10.354637740 +0100
++++ ./parser/EmperorParser.hs	2019-07-24 12:44:10.358637758 +0100
+@@ -841,6 +841,7 @@
  emperorparserReturn1 = emperorparserReturn
  emperorparserError' :: () => ((Token), [String]) -> Alex a
  emperorparserError' tk = (\(tokens, _) -> parseError tokens) tk

--- a/parser/EmperorParser.y
+++ b/parser/EmperorParser.y
@@ -126,13 +126,13 @@ body : {- empty -}          { [] }
 --          | EOL          {()}
 
 bodyBlock :: {BodyBlock}
-bodyBlock : bodyLine                        { Line $1 }
-          | "if" expr ";\n" body "else" body  { IfElse $2 $4 $6 }
-          | "while" expr ";\n" body           { While $2 $4 }
-          | "for" IDENT "<-" expr ";\n" body  { For (Ident (identifierVal $2)) $4 $6 }
-          | "repeat" expr ";\n" body          { Repeat $2 $4 }
-          | "with" assignment ";\n" body      { With $2 $4 }
-          | "switch" expr ";\n" switchBody    { Switch $2 $4 }
+bodyBlock : bodyLine                                            { Line $1 }
+          | "if" expr ";\n" "{" body "}" "else" "{" body "}"    { IfElse $2 $5 $9 }
+          | "while" expr ";\n" "{" body "}"                     { While $2 $5 }
+          | "for" IDENT "<-" expr ";\n" "{" body "}"            { For (Ident (identifierVal $2)) $4 $7 }
+          | "repeat" expr ";\n" "{" body "}"                    { Repeat $2 $5 }
+          | "with" assignment ";\n" "{" body "}"                { With $2 $5 }
+          | "switch" expr ";\n" "{" switchBody "}"              { Switch $2 $5 }
 
 switchBody :: {[SwitchCase]}
 switchBody : {- empty -}                    { [] }


### PR DESCRIPTION
### Problem description

Previous grammar could not adequately handle context.

### How this PR fixes the problem

Adds markers to the beginning and end of blocks to adequately delimit them in a concext-free way. Blocks now start with `:` and end with `#`. Additionally, lines may now optionally be ended with `;`.

### Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

Patches have also been updated
