### PR TITLE
Wrap logs

### DIFF
--- a/emperor.json
+++ b/emperor.json
@@ -116,6 +116,15 @@
 			"type": "flag",
 			"help": "Disable ANSI-coloured output",
 			"default": "false"
+		},
+		{
+			"short": "-w",
+			"long": "--wrap-log",
+			"dest": "wrapVal",
+			"type": "int",
+			"help": "Wrap logging output to this many characters",
+			"default": "-1",
+			"metaDest": "n"
 		}
 	]
 }

--- a/emperor.json
+++ b/emperor.json
@@ -120,7 +120,7 @@
 		{
 			"short": "-w",
 			"long": "--wrap-log",
-			"dest": "wrapVal",
+			"dest": "wrapLineLength",
 			"type": "int",
 			"help": "Wrap logging output to this many characters",
 			"default": "-1",

--- a/logging/Logger.hs
+++ b/logging/Logger.hs
@@ -10,16 +10,21 @@ Language    : Haskell2010
 
 Used to create loggers which output to @stderr@ using ANSI formatted output.
 -}
-module Logger (makeLoggers, Loggers, Logger) where
+module Logger
+    ( makeLoggers
+    , Loggers
+    , Logger
+    ) where
 
-import Args (Args, verbose, useColour, noUseColour)
-import System.IO (hPutStrLn, stderr)
+import Args (Args, noUseColour, useColour, verbose, wrapLineLength)
 import System.Console.ANSI (hSupportsANSIColor)
+import System.IO (hPutStrLn, stderr)
 
-data LogType = Info
-             | Warning
-             | Error
-             | Success
+data LogType
+    = Info
+    | Warning
+    | Error
+    | Success
 
 -- | Defines a set of logger functions.
 -- From left to right these are: errorLogger, infoLogger, successLogger, warningLogger
@@ -34,7 +39,6 @@ type Logger = String -> IO ()
 makeLoggers :: Args -> IO (Logger, Logger, Logger, Logger)
 makeLoggers args = do
     colourCompat <- hSupportsANSIColor stderr
-
     let logError = makeLogger colourCompat args Error
     let logInfo = makeVerboseLogger colourCompat args Info
     let logSuccess = makeVerboseLogger colourCompat args Success
@@ -45,35 +49,67 @@ trivialLogger :: Logger
 trivialLogger _ = return ()
 
 makeVerboseLogger :: Bool -> Args -> LogType -> Logger
-makeVerboseLogger c a t = if verbose a
-    then 
-        makeLogger c a t
-    else
-        trivialLogger
+makeVerboseLogger c a t =
+    if verbose a
+        then makeLogger c a t
+        else trivialLogger
 
 makeLogger :: Bool -> Args -> LogType -> Logger
 makeLogger c a t = hPutStrLn stderr . colouriseLog c a t
 
 colouriseLog :: Bool -> Args -> LogType -> String -> String
-colouriseLog c args t m = messageHeader c t ++ " " ++ m
-    where
-        messageHeader :: Bool -> LogType -> String
-        messageHeader c' t' = colour c' t' ++ messageHeaderText t' ++ "\x1b[00;00m"
+colouriseLog c args t m = (init . unlines) $ applyHeaders messageStart messageContinue $ splitToLines firstLineLength remainderLineLength m
+  where
+    messageStart :: String
+    messageStart = messageHeader c t
+    messageContinue :: String
+    messageContinue = messageStart ++ "↪  "
+    firstLineLength :: Int
+    firstLineLength = wrapLineLength args - ((length $ messageHeaderText t))
 
-        messageHeaderText :: LogType -> String
-        messageHeaderText Info      = "info"    ++ ":"
-        messageHeaderText Warning   = "warning" ++ ":"
-        messageHeaderText Error     = "error"   ++ ":"
-        messageHeaderText Success   = "success" ++ ":"
+    applyHeaders :: String -> String -> [String] -> [String]
+    applyHeaders _ _ [] = []
+    applyHeaders a b (cs:css) = (a ++ cs) : applyHeaders' b css
+        where
+            applyHeaders' :: String -> [String] -> [String]
+            applyHeaders' _ [] = []
+            applyHeaders' b' (cs':css') = (b' ++ cs') : applyHeaders' b' css' 
+    
+
+    remainderLineLength :: Int
+    remainderLineLength = wrapLineLength args - ((length $ messageHeaderText t) + 3)
+    messageHeader :: Bool -> LogType -> String
+    messageHeader c' t' = colour c' t' ++ messageHeaderText t' ++ useANSI c' args "\x1b[00;00m"
+    messageHeaderText :: LogType -> String
+    messageHeaderText Info = "info: "
+    messageHeaderText Warning = "warning: "
+    messageHeaderText Error = "error: "
+    messageHeaderText Success = "success: "
+    colour :: Bool -> LogType -> String
+    colour c'' Info = useANSI c'' args "\x1b[01;34m"
+    colour c'' Warning = useANSI c'' args "\x1b[01;93m"
+    colour c'' Error = useANSI c'' args "\x1b[01;31m"
+    colour c'' Success = useANSI c'' args "\x1b[01;32m"
+    useANSI :: Bool -> Args -> String -> String
+    useANSI colourSupported a s =
+        if useANSIColour
+            then s
+            else ""
+      where
+        useANSIColour :: Bool
+        useANSIColour = useColour a || (not (noUseColour a) && colourSupported)
+
+splitToLines :: Int -> Int -> String -> [String]
+splitToLines f r s
+    | f <= 0 || r <= 0 = [show f, show r, s]
+    | otherwise = firstF : otherLines
+        where
+            (firstF, rest) = splitAt f s
+            otherLines = splitToLines' r rest
+            splitToLines' :: Int -> String -> [String]
+            splitToLines' _ [] = []
+            splitToLines' r' s' = line : others
+                where
+                    (line, rest') = splitAt r' s'
+                    others = splitToLines' r' rest'
         
-        colour :: Bool -> LogType -> String
-        colour c'' Info     = useANSI c'' args "\x1b[01;34m"
-        colour c'' Warning  = useANSI c'' args "\x1b[01;93m"
-        colour c'' Error    = useANSI c'' args "\x1b[01;31m"
-        colour c'' Success  = useANSI c'' args "\x1b[01;32m"
-
-        useANSI :: Bool -> Args -> String -> String
-        useANSI colourSupported a s = if useANSIColour then s else ""
-            where 
-                useANSIColour :: Bool
-                useANSIColour = useColour a || (not (noUseColour a) && colourSupported)

--- a/logging/Logger.hs
+++ b/logging/Logger.hs
@@ -101,7 +101,7 @@ colouriseLog c args t m = (init . unlines) $ applyHeaders messageStart messageCo
 
 splitToLines :: Int -> Int -> String -> [String]
 splitToLines f r s
-    | f <= 0 || r <= 0 = [show f, show r, s]
+    | f <= 0 || r <= 0 = [s]
     | otherwise = firstF : otherLines
         where
             (firstF, rest) = splitAt f s


### PR DESCRIPTION
### Problem description

Logs could look more readable for humans if they are length-wrapped.

### How this PR fixes the problem

This PR wraps on a specified line length (given by an argument). By default, no wrapping is applied.

### Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

This implementation does not wrap on words, so it is very likely that words are cut in half by this change.
