### PR TITLE
Line numbers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.hs]
+[*.{hs,x,y}]
 max_line_length = 120
 indent_style = space
 indent_size = 4

--- a/Formatter/Formatter.hs
+++ b/Formatter/Formatter.hs
@@ -173,7 +173,7 @@ instance Format BodyLine where
     format ctx (AssignmentC a) = indent ctx ++ format ctx a
     format ctx (QueueC q) = indent ctx ++ format ctx q
     format ctx (CallC c) = indent ctx ++ format ctx c
-    format ctx (Return e) = indent ctx ++ "return " ++ format ctx e
+    format ctx (Return e _) = indent ctx ++ "return " ++ format ctx e
 
 -- | Assignments may be formatted using their left and right sides
 instance Format Assignment where

--- a/Formatter/Formatter.hs
+++ b/Formatter/Formatter.hs
@@ -17,6 +17,8 @@ module Formatter.Formatter
     , FormatContext
     ) where
 
+import Data.List (intercalate, sort)
+import Data.Map ((!), keys)
 import Parser.AST
     ( AST(..)
     , Assignment(..)
@@ -37,8 +39,6 @@ import Parser.AST
     , TypeComparison(..)
     , Value(..)
     )
-import Data.List (intercalate, sort)
-import Data.Map ((!), keys)
 import Types.Results (EmperorType(..), Purity(..))
 
 -- | The information required to format code in a given context

--- a/Formatter/Formatter.hs
+++ b/Formatter/Formatter.hs
@@ -66,22 +66,22 @@ instance Format AST where
 
 -- | Imports may be formatted as a sorted list of their elements
 instance Format Import where
-    format ctx (Import l Nothing) = "import " ++ format ctx l
-    format ctx (Import l (Just is)) =
+    format ctx (Import l Nothing _) = "import " ++ format ctx l
+    format ctx (Import l (Just is) _) =
         "import " ++ format ctx l ++ " (" ++ intercalate ", " (format ctx <$> sort is) ++ ")"
 
 -- | Import locations may be formatted by their type
 instance Format ImportLocation where
-    format ctx (ImportLocation Global i) = "<" ++ format ctx i ++ ">"
-    format ctx (ImportLocation Local i) = "\"" ++ format ctx i ++ "\""
+    format ctx (ImportLocation Global i _) = "<" ++ format ctx i ++ ">"
+    format ctx (ImportLocation Local i _) = "\"" ++ format ctx i ++ "\""
 
 -- | Module headers may be formatted with their docs and name
 instance Format ModuleHeader where
-    format ctx (Module i) = "module " ++ format ctx i
+    format ctx (Module i _) = "module " ++ format ctx i
 
 -- | Module items may be formatted by their contents
 instance Format ModuleItem where
-    format ctx (Component i c bs) =
+    format ctx (Component i c bs _) =
         "component " ++
         format ctx i ++ typeComparisonString ++ ":\n" ++ unlines (format (ctx + 1) <$> bs) ++ indent ctx ++ "#\n"
       where
@@ -90,7 +90,7 @@ instance Format ModuleItem where
              in if null s
                     then ""
                     else ' ' : s
-    format ctx (TypeClass i c bs) =
+    format ctx (TypeClass i c bs _) =
         "class " ++
         format ctx i ++ typeComparisonString ++ ":\n" ++ unlines (format (ctx + 1) <$> bs) ++ indent ctx ++ "#\n"
       where
@@ -99,16 +99,16 @@ instance Format ModuleItem where
              in if null s
                     then ""
                     else ' ' : s
-    format ctx (FunctionItem f) = format ctx f ++ "\n"
+    format ctx (FunctionItem f _) = format ctx f ++ "\n"
 
 formatTypeComparisons :: FormatContext -> Maybe [TypeComparison] -> String
 formatTypeComparisons _ Nothing = ""
 formatTypeComparisons ctx (Just cs) = unwords $ format ctx <$> cs
 
 instance Format FunctionDef where
-    format ctx (FunctionDef (FunctionTypeDef i t) is bs) =
+    format ctx (FunctionDef (FunctionTypeDef i t p) is bs _) =
         indent ctx ++
-        format ctx (FunctionTypeDef i t) ++
+        format ctx (FunctionTypeDef i t p) ++
         "\n" ++ indent ctx ++ format ctx i ++ params ++ ":\n" ++ unlines (format (ctx + 1) <$> bs) ++ indent ctx ++ "#"
       where
         params =
@@ -118,12 +118,12 @@ instance Format FunctionDef where
         paramIdentifierString = format ctx is
 
 instance Format FunctionTypeDef where
-    format ctx (FunctionTypeDef i t) = format ctx i ++ " :: " ++ format ctx t
+    format ctx (FunctionTypeDef i t _) = format ctx i ++ " :: " ++ format ctx t
 
 -- | Type comparisons are formatted with whitespace
 instance Format TypeComparison where
-    format ctx (IsSubType i) = "<: " ++ format ctx i
-    format ctx (IsSubTypeWithImplementor i i') = "<:" ++ format ctx i ++ " <~ " ++ format ctx i'
+    format ctx (IsSubType i _) = "<: " ++ format ctx i
+    format ctx (IsSubTypeWithImplementor i i' _) = "<:" ++ format ctx i ++ " <~ " ++ format ctx i'
 
 -- | Types can be formatted as they would appear
 instance Format EmperorType where
@@ -146,27 +146,27 @@ instance Format EmperorType where
 
 -- | Body block may be formatted with included code indented one layer further
 instance Format BodyBlock where
-    format ctx (Line l) = format ctx l
-    format ctx (IfElse c b1 b2) =
+    format ctx (Line l _) = format ctx l
+    format ctx (IfElse c b1 b2 _) =
         unlines $
         [indent ctx ++ "if " ++ format (ctx + 1) c] ++
         (format (ctx + 1) <$> b1) ++ [indent ctx ++ "else"] ++ (format (ctx + 1) <$> b2) ++ [indent ctx ++ "#"]
-    format ctx (While c b) =
+    format ctx (While c b _) =
         unlines $ [indent ctx ++ "while " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
-    format ctx (For i e b) =
+    format ctx (For i e b _) =
         unlines $
         [indent ctx ++ "for " ++ format (ctx + 1) i ++ " <- " ++ format (ctx + 1) e] ++
         (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
-    format ctx (Repeat c b) =
+    format ctx (Repeat c b _) =
         unlines $ [indent ctx ++ "repeat " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
-    format ctx (With a b) =
+    format ctx (With a b _) =
         unlines $ [indent ctx ++ "with " ++ format (ctx + 1) a] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
-    format ctx (Switch c s) =
+    format ctx (Switch c s _) =
         unlines $ [indent ctx ++ "switch " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> s) ++ [indent ctx ++ "#"]
 
 -- | Switch-cases may be formatted with their case contents
 instance Format SwitchCase where
-    format ctx (SwitchCase e b) = indent ctx ++ format (ctx + 1) e ++ " -> " ++ format (ctx + 1) b
+    format ctx (SwitchCase e b _) = indent ctx ++ format (ctx + 1) e ++ " -> " ++ format (ctx + 1) b
 
 -- | Body-lines may be formatted by their structure
 instance Format BodyLine where
@@ -177,40 +177,40 @@ instance Format BodyLine where
 
 -- | Assignments may be formatted using their left and right sides
 instance Format Assignment where
-    format ctx (Assignment t i e) = unwords [format ctx t, format ctx i, "=", format (ctx + 1) e]
+    format ctx (Assignment t i e _) = unwords [format ctx t, format ctx i, "=", format (ctx + 1) e]
 
 -- | Queue statements may be formatted using their left and right sides
 instance Format Queue where
-    format ctx (Queue t i e) = unwords [format ctx t, format ctx i, "=", format (ctx + 1) e]
+    format ctx (Queue t i e _) = unwords [format ctx t, format ctx i, "=", format (ctx + 1) e]
 
 -- | Expressions may be formatted according to their context
 instance Format Expr where
-    format ctx (Value v) = format ctx v
-    format ctx (Neg e) = '-' : format ctx e
-    format ctx (Not e) = '!' : format ctx e
-    format ctx (Add e1 e2) = formatBinOp ctx "+" e1 e2
-    format ctx (Subtract e1 e2) = formatBinOp ctx "-" e1 e2
-    format ctx (Multiply e1 e2) = formatBinOp ctx "*" e1 e2
-    format ctx (Divide e1 e2) = formatBinOp ctx "/" e1 e2
-    format ctx (Modulo e1 e2) = formatBinOp ctx "%" e1 e2
-    format ctx (Less e1 e2) = formatBinOp ctx "<" e1 e2
-    format ctx (LessOrEqual e1 e2) = formatBinOp ctx "<=" e1 e2
-    format ctx (Greater e1 e2) = formatBinOp ctx ">" e1 e2
-    format ctx (GreaterOrEqual e1 e2) = formatBinOp ctx ">=" e1 e2
-    format ctx (Equal e1 e2) = formatBinOp ctx "==" e1 e2
-    format ctx (NotEqual e1 e2) = formatBinOp ctx "!=" e1 e2
-    format ctx (AndStrict e1 e2) = formatBinOp ctx "&" e1 e2
-    format ctx (AndLazy e1 e2) = formatBinOp ctx "&&" e1 e2
-    format ctx (OrStrict e1 e2) = formatBinOp ctx "|" e1 e2
-    format ctx (OrLazy e1 e2) = formatBinOp ctx "||" e1 e2
-    format ctx (Implies e1 e2) = formatBinOp ctx "=>" e1 e2
-    format ctx (Xor e1 e2) = formatBinOp ctx "^" e1 e2
-    format ctx (ShiftLeft e1 e2) = formatBinOp ctx "<<" e1 e2
-    format ctx (ShiftRight e1 e2) = formatBinOp ctx ">>" e1 e2
-    format ctx (ShiftRightSameSign e1 e2) = formatBinOp ctx ">>>" e1 e2
-    format ctx (Set l) = "(" ++ format ctx l ++ "}"
-    format ctx (Tuple l) = "(" ++ format ctx l ++ ")"
-    format ctx (List l) = "[" ++ format ctx l ++ "]"
+    format ctx (Value v _) = format ctx v
+    format ctx (Neg e _) = '-' : format ctx e
+    format ctx (Not e _) = '!' : format ctx e
+    format ctx (Add e1 e2 _) = formatBinOp ctx "+" e1 e2
+    format ctx (Subtract e1 e2 _) = formatBinOp ctx "-" e1 e2
+    format ctx (Multiply e1 e2 _) = formatBinOp ctx "*" e1 e2
+    format ctx (Divide e1 e2 _) = formatBinOp ctx "/" e1 e2
+    format ctx (Modulo e1 e2 _) = formatBinOp ctx "%" e1 e2
+    format ctx (Less e1 e2 _) = formatBinOp ctx "<" e1 e2
+    format ctx (LessOrEqual e1 e2 _) = formatBinOp ctx "<=" e1 e2
+    format ctx (Greater e1 e2 _) = formatBinOp ctx ">" e1 e2
+    format ctx (GreaterOrEqual e1 e2 _) = formatBinOp ctx ">=" e1 e2
+    format ctx (Equal e1 e2 _) = formatBinOp ctx "==" e1 e2
+    format ctx (NotEqual e1 e2 _) = formatBinOp ctx "!=" e1 e2
+    format ctx (AndStrict e1 e2 _) = formatBinOp ctx "&" e1 e2
+    format ctx (AndLazy e1 e2 _) = formatBinOp ctx "&&" e1 e2
+    format ctx (OrStrict e1 e2 _) = formatBinOp ctx "|" e1 e2
+    format ctx (OrLazy e1 e2 _) = formatBinOp ctx "||" e1 e2
+    format ctx (Implies e1 e2 _) = formatBinOp ctx "=>" e1 e2
+    format ctx (Xor e1 e2 _) = formatBinOp ctx "^" e1 e2
+    format ctx (ShiftLeft e1 e2 _) = formatBinOp ctx "<<" e1 e2
+    format ctx (ShiftRight e1 e2 _) = formatBinOp ctx ">>" e1 e2
+    format ctx (ShiftRightSameSign e1 e2 _) = formatBinOp ctx ">>>" e1 e2
+    format ctx (Set l _) = "(" ++ format ctx l ++ "}"
+    format ctx (Tuple l _) = "(" ++ format ctx l ++ ")"
+    format ctx (List l _) = "[" ++ format ctx l ++ "]"
 
 -- | Binary operators are formatted with the operator symbol surrounded by spaces and the formatted left and right expressions
 formatBinOp ::
@@ -221,21 +221,21 @@ formatBinOp ctx op e1 e2 = format ctx e1 ++ " " ++ op ++ " " ++ format ctx e2
 
 -- | Values are formatted according to their type
 instance Format Value where
-    format _ (Integer i) = show i
-    format _ (Real r) = show r
-    format _ (Char c) = show c
-    format ctx (IdentV i) = format ctx i
-    format _ (StringV s) = show s
-    format _ (Bool b) =
+    format _ (Integer i _) = show i
+    format _ (Real r _) = show r
+    format _ (Char c _) = show c
+    format ctx (IdentV i _) = format ctx i
+    format _ (StringV s _) = show s
+    format _ (Bool b _) =
         if b
             then "true"
             else "false"
-    format _ IDC = "_"
-    format ctx (CallV c) = format ctx c
+    format _ (IDC _) = "_"
+    format ctx (CallV c _) = format ctx c
 
 -- | Calls are formatted by their contents
 instance Format Call where
-    format ctx (Call p i es) = format ctx p ++ format ctx i ++ '(' : format ctx es ++ ")"
+    format ctx (Call p i es _) = format ctx p ++ format ctx i ++ '(' : format ctx es ++ ")"
 
 -- | Impure functions have an "\@" in from of them, pure ones have nothing
 instance Format Purity where
@@ -244,7 +244,7 @@ instance Format Purity where
 
 -- | Identifiers are formatted as their name
 instance Format Ident where
-    format _ (Ident i) = i
+    format _ (Ident i _) = i
 
 -- | Maybe formattables may be formatted as an empty string or their contents
 instance Format a => Format (Maybe a) where

--- a/Main.hs
+++ b/Main.hs
@@ -18,9 +18,9 @@ module Main
 
 import Args (Args, doFormat, entryPoint, input, outputFile, parseArgv, version)
 import Control.Monad (when)
-import Parser.EmperorParserWrapper (AST, parse)
 import Formatter.Formatter (formatFresh)
 import Logger.Logger (Loggers, makeLoggers)
+import Parser.EmperorParserWrapper (AST, parse)
 import System.Exit (exitFailure, exitSuccess)
 import Types.Types (TypeCheckResult(..), resolveTypes, writeHeader)
 
@@ -29,9 +29,7 @@ main :: IO ()
 main = do
     args <- parseArgv
     (err, inf, scc, wrn) <- makeLoggers args
-
     when (version args) (putStrLn "emperor v1.0.0" >>= const exitSuccess)
-
     if input args == ""
         then wrn "No input files detected, reading from stdin"
         else inf $ "Using input file " ++ input args

--- a/Parser/AST.hs
+++ b/Parser/AST.hs
@@ -126,10 +126,10 @@ data SwitchCase =
 
 -- | Data-structure for a single body-line
 data BodyLine
-    = AssignmentC Assignment AlexPosn
-    | QueueC Queue AlexPosn
-    | CallC Call AlexPosn
-    | Return (Maybe Expr) AlexPosn
+    = AssignmentC Assignment
+    | QueueC Queue
+    | CallC Call
+    | Return (Maybe Expr)
     deriving (Show)
 
 -- | Data-structure to represent an assignment statement

--- a/Parser/AST.hs
+++ b/Parser/AST.hs
@@ -129,7 +129,7 @@ data BodyLine
     = AssignmentC Assignment
     | QueueC Queue
     | CallC Call
-    | Return (Maybe Expr)
+    | Return (Maybe Expr) AlexPosn
     deriving (Show)
 
 -- | Data-structure to represent an assignment statement

--- a/Parser/AST.hs
+++ b/Parser/AST.hs
@@ -63,7 +63,9 @@ instance A.ToJSON ImportLocation where
     toJSON (ImportLocation t (Ident i _) p) = A.object ["importType" A..= t, "import" A..= pack i, "location" A..= p]
 
 instance A.FromJSON ImportLocation where
-    parseJSON (A.Object v) = ImportLocation <$> v A..: "importType" <*> (Ident <$> v A..: "import" <*> v A..: "location") <*> v A..: "location"
+    parseJSON (A.Object v) =
+        ImportLocation <$> v A..: "importType" <*> (Ident <$> v A..: "import" <*> v A..: "location") <*>
+        v A..: "location"
     parseJSON _ = fail "Expected object when parsing import datum"
 
 -- | The type of an import

--- a/Parser/AST.hs
+++ b/Parser/AST.hs
@@ -119,11 +119,9 @@ data BodyBlock
     | Switch Expr [SwitchCase] AlexPosn -- ^ A switch-case statement
     deriving (Show)
 
--- instance Functor SwitchCases where
---     fmap f (SwitchCases as) = SwitchCases (fmap f as)
 -- | Data-struecture for the switch-case statement
 data SwitchCase =
-    SwitchCase Expr BodyBlock
+    SwitchCase Expr BodyBlock AlexPosn
     deriving (Show)
 
 -- | Data-structure for a single body-line

--- a/Types/Checker.hs
+++ b/Types/Checker.hs
@@ -15,6 +15,7 @@ module Types.Checker
     , (>-)
     ) where
 
+import Data.Monoid ((<>))
 import Parser.AST
     ( AST(..)
     , Assignment(..)
@@ -28,7 +29,6 @@ import Parser.AST
     , Queue(..)
     , SwitchCase(..)
     )
-import Data.Monoid ((<>))
 import Types.Environment (TypeEnvironment(..), (=>>), fromList, insert, unsafeGet)
 import Types.Imports.Imports (getLocalEnvironment)
 import Types.Judger ((|>))

--- a/Types/Imports/Imports.hs
+++ b/Types/Imports/Imports.hs
@@ -18,6 +18,9 @@ module Types.Imports.Imports
     , Types.Imports.Imports.writeHeader
     ) where
 
+import Data.Monoid ((<>))
+import GHC.IO.Exception (ExitCode(..))
+import Logger.Logger (Loggers)
 import Parser.AST
     ( AST(..)
     , FunctionDef(..)
@@ -29,9 +32,6 @@ import Parser.AST
     , ModuleHeader(..)
     , ModuleItem(..)
     )
-import Data.Monoid ((<>))
-import GHC.IO.Exception (ExitCode(..))
-import Logger.Logger (Loggers)
 import System.Process (readProcessWithExitCode)
 import Types.Environment (TypeEnvironment(..), filterEnvironment, has, insert, newTypeEnvironment)
 import Types.Imports.JsonIO (Header(..), isHeaderFile, readHeader, writeHeader)
@@ -89,7 +89,8 @@ getEnvironment' (err, inf, scc, wrn) (Import (ImportLocation t (Ident i _) _) mi
                         then return . Right $ filterEnvironment (`elem` ((\(Ident i' _) -> i') <$> is)) g
                         else return . Left $
                              "Environment of " ++
-                             show i ++ " does not contain " ++ show (head $ filter (\(Ident i' _) -> not $ g `has` i') is)
+                             show i ++
+                             " does not contain " ++ show (head $ filter (\(Ident i' _) -> not $ g `has` i') is)
                 Nothing -> return . Right $ g
         Left m -> return $ Left m
 

--- a/Types/Imports/JsonIO.hs
+++ b/Types/Imports/JsonIO.hs
@@ -21,6 +21,7 @@ module Types.Imports.JsonIO
     ) where
 
 import Parser.AST (Ident(..), ImportLocation(..))
+import Parser.EmperorParser (AlexPosn(..))
 import Codec.Compression.GZip (compress, decompress)
 import Data.Aeson (FromJSON, ToJSON, Value(Object), (.:), (.=), eitherDecode', encode, object, parseJSON, toJSON)
 import Data.ByteString.Lazy (readFile, writeFile)
@@ -35,10 +36,10 @@ data Header =
     deriving (Show)
 
 instance ToJSON Header where
-    toJSON (Header (Ident s) ds g) = object ["name" .= s, "depends" .= ds, "environment" .= g]
+    toJSON (Header (Ident s _) ds g) = object ["name" .= s, "depends" .= ds, "environment" .= g]
 
 instance FromJSON Header where
-    parseJSON (Object v) = Header <$> (Ident <$> v .: "name") <*> v .: "depends" <*> v .: "environment"
+    parseJSON (Object v) = Header <$> (Ident <$> v .: "name" <*> (AlexPosn 1 0 1)) <*> v .: "depends" <*> v .: "environment"
     parseJSON _ = fail "Expected object when parsing header"
 
 -- | Checks whether a given header file exists

--- a/Types/Imports/JsonIO.hs
+++ b/Types/Imports/JsonIO.hs
@@ -20,12 +20,12 @@ module Types.Imports.JsonIO
     , writeHeader
     ) where
 
-import Parser.AST (Ident(..), ImportLocation(..))
-import Parser.EmperorLexer (AlexPosn(..))
 import Codec.Compression.GZip (compress, decompress)
 import Data.Aeson (FromJSON, ToJSON, Value(Object), (.:), (.=), eitherDecode', encode, object, parseJSON, toJSON)
 import Data.ByteString.Lazy (readFile, writeFile)
 import Logger.Logger (Loggers)
+import Parser.AST (Ident(..), ImportLocation(..))
+import Parser.EmperorLexer (AlexPosn(..))
 import Prelude hiding (readFile, writeFile)
 import System.Directory (doesFileExist)
 import Types.Environment (TypeEnvironment(..))
@@ -39,7 +39,8 @@ instance ToJSON Header where
     toJSON (Header (Ident s _) ds g) = object ["name" .= s, "depends" .= ds, "environment" .= g]
 
 instance FromJSON Header where
-    parseJSON (Object v) = Header <$> (Ident <$> v .: "name" <*> (return (AlexPn 1 0 1))) <*> v .: "depends" <*> v .: "environment"
+    parseJSON (Object v) =
+        Header <$> (Ident <$> v .: "name" <*> return (AlexPn 1 0 1)) <*> v .: "depends" <*> v .: "environment"
     parseJSON _ = fail "Expected object when parsing header"
 
 -- | Checks whether a given header file exists

--- a/Types/Imports/JsonIO.hs
+++ b/Types/Imports/JsonIO.hs
@@ -21,7 +21,7 @@ module Types.Imports.JsonIO
     ) where
 
 import Parser.AST (Ident(..), ImportLocation(..))
-import Parser.EmperorParser (AlexPosn(..))
+import Parser.EmperorLexer (AlexPosn(..))
 import Codec.Compression.GZip (compress, decompress)
 import Data.Aeson (FromJSON, ToJSON, Value(Object), (.:), (.=), eitherDecode', encode, object, parseJSON, toJSON)
 import Data.ByteString.Lazy (readFile, writeFile)
@@ -39,7 +39,7 @@ instance ToJSON Header where
     toJSON (Header (Ident s _) ds g) = object ["name" .= s, "depends" .= ds, "environment" .= g]
 
 instance FromJSON Header where
-    parseJSON (Object v) = Header <$> (Ident <$> v .: "name" <*> (AlexPosn 1 0 1)) <*> v .: "depends" <*> v .: "environment"
+    parseJSON (Object v) = Header <$> (Ident <$> v .: "name" <*> (return (AlexPn 1 0 1))) <*> v .: "depends" <*> v .: "environment"
     parseJSON _ = fail "Expected object when parsing header"
 
 -- | Checks whether a given header file exists

--- a/Types/Judger.hs
+++ b/Types/Judger.hs
@@ -41,38 +41,38 @@ class Typable a where
     (|>) :: TypeEnvironment -> a -> TypeJudgementResult
 
 instance Typable Expr where
-    g |> (Value v) = g |> v
-    g |> (Neg e) =
+    g |> (Value v _) = g |> v
+    g |> (Neg e _) =
         case g |> e of
             Valid t -> assert ((g |- t <: RealP) == Pass) ("Could not unify Bool and " ++ show t) (Valid t)
             x -> x
-    g |> (Add e1 e2) = arithExpr g e1 e2
-    g |> (Subtract e1 e2) = arithExpr g e1 e2
-    g |> (Multiply e1 e2) = arithExpr g e1 e2
-    g |> (Divide e1 e2) = arithExpr g e1 e2
-    g |> (Modulo e1 e2) = arithExpr g e1 e2
-    g |> (Less e1 e2) = arithExpr g e1 e2
-    g |> (LessOrEqual e1 e2) = arithExpr g e1 e2
-    g |> (Greater e1 e2) = arithExpr g e1 e2
-    g |> (GreaterOrEqual e1 e2) = arithExpr g e1 e2
-    g |> (Equal e1 e2) = assertEquality g e1 e2
-    g |> (NotEqual e1 e2) = assertEquality g e1 e2
-    g |> (Not e) =
+    g |> (Add e1 e2 _) = arithExpr g e1 e2
+    g |> (Subtract e1 e2 _) = arithExpr g e1 e2
+    g |> (Multiply e1 e2 _) = arithExpr g e1 e2
+    g |> (Divide e1 e2 _) = arithExpr g e1 e2
+    g |> (Modulo e1 e2 _) = arithExpr g e1 e2
+    g |> (Less e1 e2 _) = arithExpr g e1 e2
+    g |> (LessOrEqual e1 e2 _) = arithExpr g e1 e2
+    g |> (Greater e1 e2 _) = arithExpr g e1 e2
+    g |> (GreaterOrEqual e1 e2 _) = arithExpr g e1 e2
+    g |> (Equal e1 e2 _) = assertEquality g e1 e2
+    g |> (NotEqual e1 e2 _) = assertEquality g e1 e2
+    g |> (Not e _) =
         case g |> e of
             Valid BoolP -> Valid BoolP
             Valid t -> Invalid $ "Could not unify bool and " ++ show t
             x -> x
-    g |> (AndStrict e1 e2) = assertExpr g BoolP e1 e2
-    g |> (AndLazy e1 e2) = assertExpr g BoolP e1 e2
-    g |> (OrStrict e1 e2) = assertExpr g BoolP e1 e2
-    g |> (OrLazy e1 e2) = assertExpr g BoolP e1 e2
-    g |> (Implies e1 e2) = assertExpr g BoolP e1 e2
-    g |> (Xor e1 e2) = assertExpr g BoolP e1 e2
-    g |> (ShiftLeft e1 e2) = assertExpr g IntP e1 e2
-    g |> (ShiftRight e1 e2) = assertExpr g IntP e1 e2
-    g |> (ShiftRightSameSign e1 e2) = assertExpr g IntP e1 e2
-    _ |> (Set []) = Valid $ ESet Any
-    g |> (Set (e:es)) =
+    g |> (AndStrict e1 e2 _) = assertExpr g BoolP e1 e2
+    g |> (AndLazy e1 e2 _) = assertExpr g BoolP e1 e2
+    g |> (OrStrict e1 e2 _) = assertExpr g BoolP e1 e2
+    g |> (OrLazy e1 e2 _) = assertExpr g BoolP e1 e2
+    g |> (Implies e1 e2 _) = assertExpr g BoolP e1 e2
+    g |> (Xor e1 e2 _) = assertExpr g BoolP e1 e2
+    g |> (ShiftLeft e1 e2 _) = assertExpr g IntP e1 e2
+    g |> (ShiftRight e1 e2 _) = assertExpr g IntP e1 e2
+    g |> (ShiftRightSameSign e1 e2 _) = assertExpr g IntP e1 e2
+    _ |> (Set [] _) = Valid $ ESet Any
+    g |> (Set (e:es) _) =
         case g |> e of
             Valid t ->
                 assert
@@ -80,8 +80,8 @@ instance Typable Expr where
                     "All elements of a set must have the same type"
                     (Valid $ EList t)
             x -> x
-    _ |> (List []) = Valid $ EList Any
-    g |> (List (e:es)) =
+    _ |> (List [] _) = Valid $ EList Any
+    g |> (List (e:es) _) =
         case g |> e of
             Valid t ->
                 assert
@@ -89,7 +89,7 @@ instance Typable Expr where
                     "All elements of a list must have the same type"
                     (Valid $ EList t)
             x -> x
-    g |> (Tuple es) =
+    g |> (Tuple es _) =
         if all isValid tjs
             then Valid (ETuple ts)
             else head (filter (not . isValid) tjs)
@@ -149,17 +149,17 @@ assertEquality g e1 e2 =
         x -> x
 
 instance Typable Value where
-    _ |> (Integer _) = Valid IntP
-    _ |> (Real _) = Valid RealP
-    _ |> (Char _) = Valid CharP
-    _ |> (Bool _) = Valid BoolP
-    _ |> IDC = Valid Unit
-    _ |> (StringV _) = Valid $ EList CharP
-    g |> (IdentV (Ident i)) = g =>> i
-    g |> (CallV c) = g |> c
+    _ |> (Integer _ _) = Valid IntP
+    _ |> (Real _ _) = Valid RealP
+    _ |> (Char _ _) = Valid CharP
+    _ |> (Bool _ _) = Valid BoolP
+    _ |> (IDC _) = Valid Unit
+    _ |> (StringV _ _) = Valid $ EList CharP
+    g |> (IdentV (Ident i _) _) = g =>> i
+    g |> (CallV c _) = g |> c
 
 instance Typable Call where
-    g |> (Call p (Ident i) es) =
+    g |> (Call p (Ident i _) es _) =
         case g =>> i of
             Valid t ->
                 case t of


### PR DESCRIPTION
### Problem description

Line numbers cannot be tracked in the current implementation of the AST.

### How this PR fixes the problem

This adds line numbers and a `GetPos` class, allowing position to be accessed without needing to explicitly use pattern-matching.

### Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

An `AlexPosn` field is added as the last entry in each AST data item as appropriate.
