### PR TITLE
Standalone compiler

### DIFF
--- a/CodeGenerator/ToC.hs
+++ b/CodeGenerator/ToC.hs
@@ -52,7 +52,11 @@ class ToCString a where
     toCString :: GenerationContext -> a -> String
 
 instance ToC AST where
-    toC c (AST m is ms) = makeHeaderLines ["#ifndef " ++ includeGuard, "#define " ++ includeGuard, ""] <> toC c m <> (foldr (<>) mempty $ toC c <$> is) <> makeHeaderLines ["", "#include <banned.h>", ""] <> (foldr (<>) mempty $ toC c <$> ms) <> makeHeaderLines ["", "#endif /* " ++ includeGuard ++ " */"]
+    toC c (AST m is ms) = makeHeaderLines ["#ifndef " ++ includeGuard, "#define " ++ includeGuard, ""] <>
+        toC c m <>
+        foldr (<>) mempty (toC c <$> is) <>
+        makeHeaderLines ["", "#include <banned.h>", ""] <>
+        foldr (<>) mempty (toC c <$> ms) <> makeHeaderLines ["", "#endif /* " ++ includeGuard ++ " */"]
         where
             includeGuard = "__" ++ (toUpper <$> ((sanitise .  sourceFile) c)) ++ "_H_"
             sanitise :: String -> String

--- a/CodeGenerator/ToC.hs
+++ b/CodeGenerator/ToC.hs
@@ -66,7 +66,9 @@ instance ToC AST where
                 replace x = x
 
 instance ToC ModuleHeader where
-    toC c (Module i p) = generatePosLines makeHeaderAndBodyLines c (Module i p) <> makeBodyLines ["#include \"" ++ destFile c ++ ".h\""] <> makeHeaderAndBodyLines ["// This is module " ++ show (toCString c i) ++ " generated from " ++ (show . sourceFile) c ++ " by emperor"] <> makeHeaderLines ["#pragma GCC dependency " ++ (show . sourceFile) c, "", "#include <OS.h>"]
+    toC c (Module i p) = generatePosLines makeHeaderAndBodyLines c (Module i p) <> headerInclude <> makeHeaderAndBodyLines ["// This is module " ++ show (toCString c i) ++ " generated from " ++ (show . sourceFile) c ++ " by emperor"] <> makeHeaderLines ["#pragma GCC dependency " ++ (show . sourceFile) c, "", "#include <OS.h>"]
+        where
+            headerInclude = makeBodyLines $ if destFile c /= "stdout" then ["#include \"" ++ destFile c ++ ".h\""] else []
 
 instance ToC Import where
     toC c (Import l _ _) = toC c l

--- a/Main.hs
+++ b/Main.hs
@@ -16,7 +16,7 @@ module Main
     ( main
     ) where
 
-import Args (Args, doFormat, entryPoint, input, outputFile, parseArgv, standaloneCompile, version)
+import Args (Args, doFormat, entryPoint, input, outputFile, parseArgv, toCOnly, version)
 import CodeGenerator.Generate (generate)
 import Control.Monad (when)
 import Formatter.Formatter (formatFresh)
@@ -52,7 +52,7 @@ main = do
                 (do inf "Outputting header..."
                     writeHeader (outputFile args ++ ".eh.json.gz") prog)
             (b,h) <- generateCode args (err, inf, scc, wrn) prog
-            if standaloneCompile args then
+            if (not . toCOnly) args then
                 nativeCompile args (err, inf, scc, wrn) (b,h)
             else if outputFile args == "-"
                 then do

--- a/Main.hs
+++ b/Main.hs
@@ -23,7 +23,7 @@ import Formatter.Formatter (formatFresh)
 import Logger.Logger (Loggers, makeLoggers)
 import Optimiser.Optimise (optimiseAST)
 import Parser.EmperorParserWrapper (AST, parse)
-import StandaloneCompiler.StandaloneCompile (nativeCompile)
+import StandaloneCompiler.Compile (nativeCompile)
 import System.Exit (exitFailure, exitSuccess)
 import Types.Types (TypeCheckResult(..), resolveTypes, writeHeader)
 
@@ -51,20 +51,20 @@ main = do
                 (not (entryPoint args) && outputFile args /= "-")
                 (do inf "Outputting header..."
                     writeHeader (outputFile args ++ ".eh.json.gz") prog)
-            (b,h) <- generateCode args (err, inf, scc, wrn) prog
-            if (not . toCOnly) args then
-                nativeCompile args (err, inf, scc, wrn) (b,h)
-            else if outputFile args == "-"
-                then do
-                    putStr h
-                    putStr b
-                else do
-                    inf $ "Writing to " ++ outputFile args ++ ".h"
-                    writeFile (outputFile args ++ ".h") h
-                    scc "Written header"
-                    inf $ "Writing to " ++ outputFile args ++ ".c"
-                    writeFile (outputFile args ++ ".c") b
-                    scc "Written payload"
+            (b, h) <- generateCode args (err, inf, scc, wrn) prog
+            if (not . toCOnly) args
+                then nativeCompile args (err, inf, scc, wrn) (b, h)
+                else if outputFile args == "-"
+                         then do
+                             putStr h
+                             putStr b
+                         else do
+                             inf $ "Writing to " ++ outputFile args ++ ".h"
+                             writeFile (outputFile args ++ ".h") h
+                             scc "Written header"
+                             inf $ "Writing to " ++ outputFile args ++ ".c"
+                             writeFile (outputFile args ++ ".c") b
+                             scc "Written payload"
 
 typeCheck :: Args -> Loggers -> AST -> IO ()
 typeCheck _ (err, inf, scc, wrn) prog = do

--- a/StandaloneCompiler/Compile.hs
+++ b/StandaloneCompiler/Compile.hs
@@ -1,13 +1,15 @@
-module StandaloneCompiler.StandaloneCompile (nativeCompile) where
+module StandaloneCompiler.Compile
+    ( nativeCompile
+    ) where
 
 import Args (Args, input, outputFile)
-import System.IO (hPutStr, stderr)
 import Logger.Logger (Loggers)
-import System.Process (readProcessWithExitCode)
 import System.Exit (ExitCode(ExitSuccess), exitFailure)
+import System.IO (hPutStr, stderr)
+import System.Process (readProcessWithExitCode)
 
-nativeCompile :: Args -> Loggers -> (String,String) -> IO ()
-nativeCompile args (err, inf, wrn, scc) (b,h) = do
+nativeCompile :: Args -> Loggers -> (String, String) -> IO ()
+nativeCompile args (err, inf, wrn, scc) (b, h) = do
     let prog = h ++ '\n' : b
     inf "Compiling natively"
     cfsr <- getCflags (err, inf, wrn, scc)
@@ -24,20 +26,22 @@ nativeCompile args (err, inf, wrn, scc) (b,h) = do
                     hPutStr stderr m
                     exitFailure
                 Right ls -> do
-                    let outFile = if outputFile args /= "-" then
-                            outputFile args
-                        else if input args /= "" then
-                            input args
-                        else
-                            "a.out"
+                    let outFile =
+                            if outputFile args /= "-"
+                                then outputFile args
+                                else if input args /= ""
+                                         then input args
+                                         else "a.out"
                     inf $ (show . outputFile) args ++ " " ++ (show . input) args ++ " " ++ show outFile
-                    (c, outs, errs) <- readProcessWithExitCode "gcc-8" (words cfs ++ ["-xc", "-", "-o", outFile] ++ words ls) prog
-                    if c /= ExitSuccess then do
-                        err "GCC produced the following error(s)"
-                        hPutStr stderr errs
-                        exitFailure
-                    else do
-                        putStr outs
+                    (c, outs, errs) <-
+                        readProcessWithExitCode "gcc-8" (words cfs ++ ["-xc", "-", "-o", outFile] ++ words ls) prog
+                    if c /= ExitSuccess
+                        then do
+                            err "GCC produced the following error(s)"
+                            hPutStr stderr errs
+                            exitFailure
+                        else do
+                            putStr outs
 
 getCflags :: Loggers -> IO (Either String String)
 getCflags (_, inf, _, _) = do
@@ -52,7 +56,6 @@ getLibs (_, inf, _, _) = do
 getFromSetup :: [String] -> IO (Either String String)
 getFromSetup fs = do
     (c, out, err) <- readProcessWithExitCode "emperor-setup" fs ""
-    if c /= ExitSuccess then
-        return $ Left err
-    else
-        return . Right $ init out
+    if c /= ExitSuccess
+        then return $ Left err
+        else return . Right $ init out

--- a/StandaloneCompiler/StandaloneCompile.hs
+++ b/StandaloneCompiler/StandaloneCompile.hs
@@ -1,0 +1,58 @@
+module StandaloneCompiler.StandaloneCompile (nativeCompile) where
+
+import Args (Args, input, outputFile)
+import System.IO (hPutStr, stderr)
+import Logger.Logger (Loggers)
+import System.Process (readProcessWithExitCode)
+import System.Exit (ExitCode(ExitSuccess), exitFailure)
+
+nativeCompile :: Args -> Loggers -> (String,String) -> IO ()
+nativeCompile args (err, inf, wrn, scc) (b,h) = do
+    let prog = h ++ '\n' : b
+    inf "Compiling natively"
+    cfsr <- getCflags (err, inf, wrn, scc)
+    case cfsr of
+        Left m -> do
+            err "Failed to get c flags from emperor-setup"
+            hPutStr stderr m
+            exitFailure
+        Right cfs -> do
+            lsr <- getLibs (err, inf, wrn, scc)
+            case lsr of
+                Left m -> do
+                    err "Failed to get libraries from emperor-setup"
+                    hPutStr stderr m
+                    exitFailure
+                Right ls -> do
+                    let outFile = if outputFile args /= "-" then
+                            outputFile args
+                        else if input args /= "" then
+                            input args
+                        else
+                            "a.out"
+                    inf $ (show . outputFile) args ++ " " ++ (show . input) args ++ " " ++ show outFile
+                    (c, outs, errs) <- readProcessWithExitCode "gcc-8" (words cfs ++ ["-xc", "-", "-o", outFile] ++ words ls) prog
+                    if c /= ExitSuccess then do
+                        err "GCC produced the following error(s)"
+                        hPutStr stderr errs
+                        exitFailure
+                    else do
+                        putStr outs
+
+getCflags :: Loggers -> IO (Either String String)
+getCflags (_, inf, _, _) = do
+    inf "Getting C flags from emperor-setup"
+    getFromSetup ["--cflags", "--entry-point"]
+
+getLibs :: Loggers -> IO (Either String String)
+getLibs (_, inf, _, _) = do
+    inf "Getting libraries from emperor-setup"
+    getFromSetup ["--libs"]
+
+getFromSetup :: [String] -> IO (Either String String)
+getFromSetup fs = do
+    (c, out, err) <- readProcessWithExitCode "emperor-setup" fs ""
+    if c /= ExitSuccess then
+        return $ Left err
+    else
+        return . Right $ init out

--- a/emperor.json
+++ b/emperor.json
@@ -83,9 +83,9 @@
 			"help": "Compiler optimisation level as specified in **gcc**"
 		},
 		{
-			"short": "-s",
-			"long": "--standalone",
-			"dest": "standaloneCompile",
+			"short": "-c",
+			"long": "--to-c",
+			"dest": "toCOnly",
 			"type": "flag",
 			"default": "false",
 			"mandatory": false,

--- a/emperor.json
+++ b/emperor.json
@@ -83,13 +83,13 @@
 			"help": "Compiler optimisation level as specified in **gcc**"
 		},
 		{
-			"short": "-c",
-			"long": "--to-c",
-			"dest": "compileCOnly",
+			"short": "-s",
+			"long": "--standalone",
+			"dest": "standaloneCompile",
 			"type": "flag",
 			"default": "false",
 			"mandatory": false,
-			"help": "Translate to C (skips compilation step)"
+			"help": "Compile the input as a single executable"
 		},
 		{
 			"short": "-o",


### PR DESCRIPTION
### Problem description

Creating a binary required at least two commands (`emperor` and a C compiler). This was annoying.

### How this PR fixes the problem

The `emperor` compiler can now call `gcc-8` on the code it creates in order to immediately create a binary.

### Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

N/A
