### PR TITLE
Bad includes

### DIFF
--- a/CodeGenerator/Context.hs
+++ b/CodeGenerator/Context.hs
@@ -21,10 +21,11 @@ module CodeGenerator.Context
     , makeContext
     , makeIndent
     , moreIndent
+    , nativeCompile
     , sourceFile
     ) where
 
-import Args (Args, entryPoint, input, outputFile, annotateSource)
+import qualified Args (Args, entryPoint, input, outputFile, annotateSource, toCOnly)
 
 data GenerationContext =
     GenerationContext
@@ -33,14 +34,15 @@ data GenerationContext =
         , destFile :: FilePath
         , indent :: Int
         , annotation :: Int
+        , nativeCompile :: Bool
         }
     deriving (Show)
 
-makeContext :: Args -> GenerationContext
-makeContext args = GenerationContext { isEntryPoint = entryPoint args, sourceFile = inputFile, indent = 0, destFile = outFile, annotation = annotateSource args }
+makeContext :: Args.Args -> GenerationContext
+makeContext args = GenerationContext { isEntryPoint = Args.entryPoint args, sourceFile = inputFile, indent = 0, destFile = outFile, annotation = Args.annotateSource args, nativeCompile = (not . Args.toCOnly) args }
     where
-        inputFile = if null $ input args then "stdin" else input args
-        outFile = if outputFile args == "-" then "stdout" else outputFile args
+        inputFile = if null $ Args.input args then "stdin" else Args.input args
+        outFile = if Args.outputFile args == "-" then "stdout" else Args.outputFile args
 
 makeIndent :: GenerationContext -> String
 makeIndent c = replicate (indent c) '\t'

--- a/CodeGenerator/ToC.hs
+++ b/CodeGenerator/ToC.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+
 {-|
 Module      : ToC
 Description : Generate C Code
@@ -11,23 +12,28 @@ Language    : Haskell2010
 
 Handles the generation of C body code, headers and appropriate directives.
 -}
-module CodeGenerator.ToC (ToC, ToCString, toC, toCString) where
+module CodeGenerator.ToC
+    ( ToC
+    , ToCString
+    , toC
+    , toCString
+    ) where
 
-import CodeGenerator.Context
-    ( GenerationContext
-    , makeIndent
-    , moreIndent
-    , sourceFile
-    , destFile
-    )
+import CodeGenerator.Context (GenerationContext, destFile, makeIndent, moreIndent, sourceFile)
 import CodeGenerator.Position (GetPos, generatePos)
-import CodeGenerator.Results (GenerationResult, makeHeaderLines, makeHeaderAndBodyLines, makeBodyLines, wrapLastBodyLine)--, makeConstant)
+import CodeGenerator.Results
+    ( GenerationResult
+    , makeBodyLines
+    , makeHeaderAndBodyLines
+    , makeHeaderLines
+    , wrapLastBodyLine
+    ) --, makeConstant)
 import Data.Char (toUpper)
 import Data.List (intercalate)
 import Data.Monoid ((<>))
 import Parser.AST
-    ( Assignment(..)
-    , AST(..)
+    ( AST(..)
+    , Assignment(..)
     , BodyBlock(..)
     , BodyLine(..)
     , Call(..)
@@ -78,28 +84,42 @@ instance ToC Import where
     toC c (Import l _ _) = toC c l
 
 instance ToC ImportLocation where
-    toC c (ImportLocation Global i p) = generatePosLines makeHeaderLines c (ImportLocation Global i p) <> makeHeaderLines ["#include <" ++ toCString c i ++ ".h>"]
-    toC c (ImportLocation Local i p) = generatePosLines makeHeaderLines c (ImportLocation Local i p) <> makeHeaderLines ["#include \"" ++ toCString c i ++ ".h\""]
+    toC c (ImportLocation Global i p) =
+        generatePosLines makeHeaderLines c (ImportLocation Global i p) <>
+        makeHeaderLines ["#include <" ++ toCString c i ++ ".h>"]
+    toC c (ImportLocation Local i p) =
+        generatePosLines makeHeaderLines c (ImportLocation Local i p) <>
+        makeHeaderLines ["#include \"" ++ toCString c i ++ ".h\""]
 
 instance ToC ModuleItem where
-    toC _ Component{} = error $ "Components have not been implemented yet, and this should have been caught at the type-checking stage??"
-    toC _ TypeClass{} = mempty
-    toC c (FunctionItem f p) = makeBodyLines [""] <> generatePosLines makeHeaderAndBodyLines c (FunctionItem f p) <> toC c f
+    toC _ Component {} =
+        error $
+        "Components have not been implemented yet, and this should have been caught at the type-checking stage??"
+    toC _ TypeClass {} = mempty
+    toC c (FunctionItem f p) =
+        makeBodyLines [""] <> generatePosLines makeHeaderAndBodyLines c (FunctionItem f p) <> toC c f
 
 instance ToC FunctionDef where
-    toC c (FunctionDef (FunctionTypeDef i t _) is bs _) = prototype <> makeBodyLines [returnString ++ " " ++ toCString c i ++ "(" ++ paramSig ++ ")", "{"] <> body <> makeBodyLines ["}"]
-        where
-            paramSig = if null inputTypes
+    toC c (FunctionDef (FunctionTypeDef i t _) is bs _) =
+        prototype <>
+        makeBodyLines [returnString ++ " " ++ toCString c i ++ "(" ++ paramSig ++ ")", "{"] <>
+        body <> makeBodyLines ["}"]
+      where
+        paramSig =
+            if null inputTypeMap
                 then "void"
-                else intercalate ", " $ (\(t',i') -> toCString c t' ++ " " ++ toCString c i') <$> zip inputTypes is
-            prototype = makeHeaderLines [ returnString ++ " " ++ toCString c i ++ "(" ++ paramsPrototypes ++ ");" ]
-            paramsPrototypes = if null inputTypes
+                else intercalate ", " $ (\(i', t') -> toCString c t' ++ " " ++ toCString c i') <$> inputTypeMap
+        prototype = makeHeaderLines [returnString ++ " " ++ toCString c i ++ "(" ++ paramsPrototypes ++ ");"]
+        paramsPrototypes =
+            if null inputTypeMap
                 then "void"
-                else intercalate ", " (toCString c <$> inputTypes)
-            body = foldr1 (<>) $ toC (moreIndent c) <$> bs
-            returnString = toCString c returnType
-            inputTypes = init $ getTypeList t
-            returnType = last $ getTypeList t
+                else intercalate ", " (toCString c <$> ((\(_, x) -> x) <$> inputTypeMap))
+        body = foldr (<>) mempty $ toC (moreIndent c) <$> bs
+        returnString = toCString c returnType
+        inputTypeMap = filter (not . isUnit) $ zip is (init $ getTypeList t)
+        isUnit (_, Unit) = True
+        isUnit _ = False
+        returnType = last $ getTypeList t
 
 instance ToCString EmperorType where
     toCString _ IntP = "int"
@@ -114,27 +134,47 @@ instance ToCString EmperorType where
     toCString _ Any = "void*"
     toCString _ Unit = "void"
 
-instance ToC BodyBlock where
+instance ToC BodyBlock
     -- TODO: make blocks actually work!
+                                        where
     toC c (Line l _) = toC c l
-    toC c (IfElse e _ _ _) = makeBodyLines ([makeIndent c ++ "if (" ++ toCString (moreIndent c) e ++ ")", makeIndent c ++ "{"] ++ ["}", "else", "{"] ++ ["}"])
-    toC c (While e _ _) = makeBodyLines ([makeIndent c ++ "while (" ++ toCString (moreIndent c) e ++ ")", makeIndent c ++ "{"] ++ [makeIndent c ++ "}"])
-    toC _ (For _ _ _ _) = makeBodyLines ["for..."]
-    toC c (Repeat e _ _) = makeBodyLines ([makeIndent c ++ "for (int i = 0; i < " ++ toCString (moreIndent c) e ++ "; i++)", makeIndent c ++ "{"] ++ [makeIndent c ++ "}"])
-    toC _ (With _ _ _) = makeBodyLines ["with"]
-    toC _ (Switch _ _ _) = makeBodyLines ["switch"]
+    toC c (IfElse e bs1 bs2 p) =
+        generatePosLines makeBodyLines c (IfElse e bs1 bs2 p) <>
+        makeBodyLines [makeIndent c ++ "if (" ++ toCString (moreIndent c) e ++ ")", makeIndent c ++ "{"] <>
+        (foldl (<>) mempty $ toC (moreIndent c) <$> bs1) <>
+        makeBodyLines [makeIndent c ++ "}", makeIndent c ++ "else", makeIndent c ++ "{"] <>
+        (foldl (<>) mempty $ toC (moreIndent c) <$> bs2) <> makeBodyLines [makeIndent c ++ "}"]
+    toC c (While e bs p) =
+        generatePosLines makeBodyLines c (While e bs p) <>
+        makeBodyLines [makeIndent c ++ "while (" ++ toCString (moreIndent c) e ++ ")", makeIndent c ++ "{"] <>
+        (foldl (<>) mempty $ toC (moreIndent c) <$> bs) <> makeBodyLines [makeIndent c ++ "}"]
+    toC _ (For _ _ _ _) = error "For loops have not been implemented yet"
+    toC c (Repeat e _ _) =
+        makeBodyLines
+            ([makeIndent c ++ "for (int i = 0; i < " ++ toCString (moreIndent c) e ++ "; i++)", makeIndent c ++ "{"] ++
+             [makeIndent c ++ "}"])
+    toC _ (With _ _ _ _ _) = error "With has not been implemented yet" -- Use if (1) for scoping
+    toC _ (Switch _ _ _) = error "Switches have not been implemented yet"
 
 instance ToC BodyLine where
-    toC c (AssignmentC x) = generatePosLines makeBodyLines c x <> wrapLastBodyLine (toC c x) (\x' -> makeIndent c ++ x' ++ ";")
-    toC c (QueueC x) = generatePosLines makeBodyLines c x <> wrapLastBodyLine (toC c x) (\x' -> makeIndent c ++ x' ++ ";")
-    toC c (CallC x) = generatePosLines makeBodyLines c x <> wrapLastBodyLine (toC c x) (\x' -> makeIndent c ++ x' ++ ";")
-    toC c (Return Nothing p) = generatePosLines makeBodyLines c (Return Nothing p) <> makeBodyLines [makeIndent c ++ "return" ++ ";"]
-    toC c (Return (Just v) p) = generatePosLines makeBodyLines c (Return (Just v) p) <> makeBodyLines [makeIndent c ++ "return " ++ toCString c v ++ ";"]
+    toC c (AssignmentC x) =
+        generatePosLines makeBodyLines c x <> wrapLastBodyLine (toC c x) (\x' -> makeIndent c ++ x' ++ ";")
+    toC c (QueueC x) =
+        generatePosLines makeBodyLines c x <> wrapLastBodyLine (toC c x) (\x' -> makeIndent c ++ x' ++ ";")
+    toC c (CallC x) =
+        generatePosLines makeBodyLines c x <> wrapLastBodyLine (toC c x) (\x' -> makeIndent c ++ x' ++ ";")
+    toC c (Return Nothing p) =
+        generatePosLines makeBodyLines c (Return Nothing p) <> makeBodyLines [makeIndent c ++ "return" ++ ";"]
+    toC c (Return (Just v) p) =
+        generatePosLines makeBodyLines c (Return (Just v) p) <>
+        makeBodyLines [makeIndent c ++ "return " ++ toCString c v ++ ";"]
 
 generatePosLines :: GetPos a => ([String] -> GenerationResult) -> GenerationContext -> a -> GenerationResult
-generatePosLines f c x = let s = generatePos c x in if null s
-    then mempty
-    else f [s]
+generatePosLines f c x =
+    let s = generatePos c x
+     in if null s
+            then mempty
+            else f [s]
 
 instance ToC Assignment where
     toC c (Assignment Nothing i e _) = makeBodyLines [toCString c i ++ " = " ++ toCString c e]
@@ -184,7 +224,10 @@ instance ToCString Value where
     toCString _ (Char c _) = show c
     toCString _ (StringV s _) = show s
     toCString c (IdentV i _) = toCString c i
-    toCString _ (Bool b _) = if b then "1" else "0"
+    toCString _ (Bool b _) =
+        if b
+            then "1"
+            else "0"
     toCString c (CallV c' _) = toCString c c'
 
 instance ToC Call where

--- a/Formatter/Formatter.hs
+++ b/Formatter/Formatter.hs
@@ -149,20 +149,20 @@ instance Format BodyBlock where
     format ctx (Line l _) = format ctx l
     format ctx (IfElse c b1 b2 _) =
         unlines $
-        [indent ctx ++ "if " ++ format (ctx + 1) c] ++
-        (format (ctx + 1) <$> b1) ++ [indent ctx ++ "else"] ++ (format (ctx + 1) <$> b2) ++ [indent ctx ++ "#"]
+        [indent ctx ++ "if " ++ format (ctx + 1) c ++ ":"] ++
+        (format (ctx + 1) <$> b1) ++ [indent ctx ++ "#else:"] ++ (format (ctx + 1) <$> b2) ++ [indent ctx ++ "#"]
     format ctx (While c b _) =
-        unlines $ [indent ctx ++ "while " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
+        unlines $ [indent ctx ++ "while " ++ format (ctx + 1) c ++ ":"] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
     format ctx (For i e b _) =
         unlines $
-        [indent ctx ++ "for " ++ format (ctx + 1) i ++ " <- " ++ format (ctx + 1) e] ++
+        [indent ctx ++ "for " ++ format (ctx + 1) i ++ " <- " ++ format (ctx + 1) e ++ ":"] ++
         (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
     format ctx (Repeat c b _) =
-        unlines $ [indent ctx ++ "repeat " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
-    format ctx (With a b _) =
-        unlines $ [indent ctx ++ "with " ++ format (ctx + 1) a] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
+        unlines $ [indent ctx ++ "repeat " ++ format (ctx + 1) c ++ ":"] ++ (format (ctx + 1) <$> b) ++ [indent ctx ++ "#"]
+    format ctx (With t i e bs p) =
+        unlines $ [indent ctx ++ "with " ++ format (ctx + 1) (Assignment (Just t) i e p) ++ ":"] ++ (format (ctx + 1) <$> bs) ++ [indent ctx ++ "#"]
     format ctx (Switch c s _) =
-        unlines $ [indent ctx ++ "switch " ++ format (ctx + 1) c] ++ (format (ctx + 1) <$> s) ++ [indent ctx ++ "#"]
+        unlines $ [indent ctx ++ "switch " ++ format (ctx + 1) c ++ ":"] ++ (format (ctx + 1) <$> s) ++ [indent ctx ++ "#"]
 
 -- | Switch-cases may be formatted with their case contents
 instance Format SwitchCase where

--- a/Parser/AST.hs
+++ b/Parser/AST.hs
@@ -117,7 +117,7 @@ data BodyBlock
     | While Expr [BodyBlock] AlexPosn -- ^ A while-loop
     | For Ident Expr [BodyBlock] AlexPosn -- ^ A for-loop
     | Repeat Expr [BodyBlock] AlexPosn -- ^ A repeat-loop
-    | With Assignment [BodyBlock] AlexPosn -- ^ A resource acquisition
+    | With EmperorType Ident Expr [BodyBlock] AlexPosn -- ^ A resource acquisition
     | Switch Expr [SwitchCase] AlexPosn -- ^ A switch-case statement
     deriving (Show)
 

--- a/Parser/EmperorParser.y
+++ b/Parser/EmperorParser.y
@@ -201,7 +201,7 @@ bodyBlock : bodyLine ";"                                    { Line $1 (getPos $1
           | "while" expr ":" body "#"                       { While $2 $4 (position $1) }
           | "for" IDENT "<-" expr ":" body "#"              { For (Ident (identifierVal $2) (position $1)) $4 $6 (position $1) }
           | "repeat" expr ":" body "#"                      { Repeat $2 $4 (position $1) }
-          | "with" assignment ":" body "#"                  { With $2 $4 (position $1) }
+          | "with" typedef IDENT "<-" expr ":" body "#"     { With $2 (Ident (identifierVal $3) (position $3)) $5 $7 (position $1) }
           | "switch" expr ":" switchBody "#"                { Switch $2 $4 (position $1) }
 
 switchBody :: {[SwitchCase]}

--- a/Parser/Position.hs
+++ b/Parser/Position.hs
@@ -78,7 +78,7 @@ instance GetPos BodyBlock where
     getPos (While _ _ p) = p
     getPos (For _ _ _ p) = p
     getPos (Repeat _ _ p) = p
-    getPos (With _ _ p) = p
+    getPos (With _ _ _ _ p) = p
     getPos (Switch _ _ p) = p
 
 instance GetPos SwitchCase where

--- a/StandaloneCompiler/Compile.hs
+++ b/StandaloneCompiler/Compile.hs
@@ -19,6 +19,7 @@ nativeCompile args (err, inf, wrn, scc) (b, h) = do
             hPutStr stderr m
             exitFailure
         Right cfs -> do
+            scc "Got C flags"
             lsr <- getLibs (err, inf, wrn, scc)
             case lsr of
                 Left m -> do
@@ -26,13 +27,14 @@ nativeCompile args (err, inf, wrn, scc) (b, h) = do
                     hPutStr stderr m
                     exitFailure
                 Right ls -> do
+                    scc "Got libraries"
                     let outFile =
                             if outputFile args /= "-"
                                 then outputFile args
                                 else if input args /= ""
                                          then input args
                                          else "a.out"
-                    inf $ (show . outputFile) args ++ " " ++ (show . input) args ++ " " ++ show outFile
+                    inf $ "Running gcc, outputting to " ++ outFile
                     (c, outs, errs) <-
                         readProcessWithExitCode "gcc-8" (words cfs ++ ["-xc", "-", "-o", outFile] ++ words ls) prog
                     if c /= ExitSuccess
@@ -41,6 +43,7 @@ nativeCompile args (err, inf, wrn, scc) (b, h) = do
                             hPutStr stderr errs
                             exitFailure
                         else do
+                            scc "C compilation complete"
                             putStr outs
 
 getCflags :: Loggers -> IO (Either String String)

--- a/StandaloneCompiler/Compile.hs
+++ b/StandaloneCompiler/Compile.hs
@@ -9,10 +9,10 @@ import System.IO (hPutStr, stderr)
 import System.Process (readProcessWithExitCode)
 
 nativeCompile :: Args -> Loggers -> (String, String) -> IO ()
-nativeCompile args (err, inf, wrn, scc) (b, h) = do
+nativeCompile args (err, inf, scc, wrn) (b, h) = do
     let prog = h ++ '\n' : b
     inf "Compiling natively"
-    cfsr <- getCflags (err, inf, wrn, scc)
+    cfsr <- getCflags (err, inf, scc, wrn)
     case cfsr of
         Left m -> do
             err "Failed to get c flags from emperor-setup"
@@ -20,7 +20,7 @@ nativeCompile args (err, inf, wrn, scc) (b, h) = do
             exitFailure
         Right cfs -> do
             scc "Got C flags"
-            lsr <- getLibs (err, inf, wrn, scc)
+            lsr <- getLibs (err, inf, scc, wrn)
             case lsr of
                 Left m -> do
                     err "Failed to get libraries from emperor-setup"

--- a/Types/Checker.hs
+++ b/Types/Checker.hs
@@ -103,13 +103,16 @@ checkLine g l = case l of
             Left m -> Left m
     where
         checkEnvironmentMutatorLine :: EmperorType -> String -> Expr -> Either String TypeEnvironment
-        checkEnvironmentMutatorLine t i e = case g =>> i of
-            Invalid _ -> case g |> e of
-                Valid t' -> case g |- t' <: t of
-                    Pass -> Right $ insert i t g
-                    Fail m -> Left m
-                Invalid m -> Left m
-            Valid _ -> Left $ "Identifier " ++ show i ++ " already exists in the current scope"
+        checkEnvironmentMutatorLine t i e = if t == Unit then
+                Left "Assignments to the unit are valid but pointless, please remove this."
+            else
+                case g =>> i of
+                Invalid _ -> case g |> e of
+                    Valid t' -> case g |- t' <: t of
+                        Pass -> Right $ insert i t g
+                        Fail m -> Left m
+                    Invalid m -> Left m
+                Valid _ -> Left $ "Identifier " ++ show i ++ " already exists in the current scope"
 
         checkEnvironmentNonMutatorLine :: String -> Expr -> Either String TypeEnvironment
         checkEnvironmentNonMutatorLine i e = case g =>> i of

--- a/Types/Environment.hs
+++ b/Types/Environment.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-|
 Module      : TypeEnvironment
 Description : Typing results for emperor
@@ -13,7 +15,11 @@ This module defines the type environments of Emperor programs.
 module Types.Environment
     ( (=>>)
     , filterEnvironment
-    , fromList
+    , makeEnvironment
+    , pushReturnType
+    , getEnvironmentPurity
+    , getReturnType
+    , setPurity
     , has
     , newTypeEnvironment
     , TypeEnvironment(..)
@@ -21,21 +27,24 @@ module Types.Environment
     , unsafeGet
     ) where
 
-import Data.Aeson (FromJSON, ToJSON, Value(..), parseJSON, toJSON)
-import Types.Results (EmperorType, TypeJudgementResult(..))
+import Data.Aeson (FromJSON, ToJSON, Value(..), (.:), (.=), object, parseJSON, toJSON)
+import Types.Results (EmperorType, Purity(..), TypeJudgementResult(..))
+import GHC.Generics (Generic)
 
 -- | An environment which maps names to types
-newtype TypeEnvironment =
-    TypeEnvironment [(String, EmperorType)]
+data TypeEnvironment =
+    TypeEnvironment [(String, EmperorType)] Purity [EmperorType]
     deriving (Eq, Show)
 
 instance Monoid TypeEnvironment where
     mempty = newTypeEnvironment
-    mappend (TypeEnvironment g) (TypeEnvironment g') = TypeEnvironment $ g ++ g'
+    mappend (TypeEnvironment g p ts) (TypeEnvironment g' p' ts') = TypeEnvironment (g ++ g') p'' (ts ++ ts')
+        where
+            p'' = if p == Pure && p' == Pure then Pure else Impure
 
 -- | Creates a fresh type-environment
 newTypeEnvironment :: TypeEnvironment
-newTypeEnvironment = TypeEnvironment []
+newTypeEnvironment = TypeEnvironment [] Impure []
 
 -- | Check whether a given type environment contains a symbol of the given name
 has :: TypeEnvironment -> String -> Bool
@@ -46,33 +55,49 @@ has g s =
 
 -- | Get a value from a type environment
 (=>>) :: TypeEnvironment -> String -> TypeJudgementResult
-TypeEnvironment [] =>> s = Invalid $ "Identifier " ++ show s ++ " not in current scope"
-TypeEnvironment ((i, t):ms) =>> s =
+TypeEnvironment [] _ _ =>> s = Invalid $ "Identifier " ++ show s ++ " not in current scope"
+TypeEnvironment ((i, t):ms) p ts =>> s =
     if s == i
         then Valid t
-        else TypeEnvironment ms =>> s
+        else TypeEnvironment ms p ts =>> s
 
 -- | Get a value from a type environment under the assertion that it already
 -- exists. This should only be used for types guaranteed to be in the prelude.
 unsafeGet :: String -> TypeEnvironment -> EmperorType
-unsafeGet s (TypeEnvironment []) =
-    error $ "Identifier " ++ show s ++ " not in current scope, also, the programmer used an unsafe operation!"
-unsafeGet s (TypeEnvironment ((i, t):ms)) =
+unsafeGet s (TypeEnvironment [] _ _) =
+    error $
+    "Identifier " ++
+    show s ++
+    " not in current scope, also, the compiler " ++ "programmer used an unsafe operation where it wasn't safe to do so!"
+unsafeGet s (TypeEnvironment ((i,t):ms) p ts) =
     if s == i
         then t
-        else unsafeGet s (TypeEnvironment ms)
+        else unsafeGet s (TypeEnvironment ms p ts)
 
 -- | Add a type assertion to the environment
 insert :: String -> EmperorType -> TypeEnvironment -> TypeEnvironment
-insert s t (TypeEnvironment m) = TypeEnvironment ((s, t) : m)
+insert s t (TypeEnvironment m p ts) = TypeEnvironment ((s,t) : m) p ts
 
--- | Create a type environment from a list
-fromList :: [(String, EmperorType)] -> TypeEnvironment
-fromList = TypeEnvironment
+-- | Create a type environment from a list and other data
+makeEnvironment :: [(String, EmperorType)] -> Purity -> [EmperorType] -> TypeEnvironment
+makeEnvironment = TypeEnvironment
+
+pushReturnType :: EmperorType -> TypeEnvironment -> TypeEnvironment
+pushReturnType t (TypeEnvironment ms p ts) = TypeEnvironment ms p (t : ts)
+
+getReturnType :: TypeEnvironment -> Either String EmperorType
+getReturnType (TypeEnvironment _ _ []) = Left "Could not obtain return type outside of function"
+getReturnType (TypeEnvironment _ _ ts) = Right $ head ts
+
+setPurity :: Purity -> TypeEnvironment -> TypeEnvironment
+setPurity p (TypeEnvironment ms _ ts) = TypeEnvironment ms p ts
+
+getEnvironmentPurity :: TypeEnvironment -> Purity
+getEnvironmentPurity (TypeEnvironment _ p _) = p
 
 -- | Filter the entries of the type environment
 filterEnvironment :: (String -> Bool) -> TypeEnvironment -> TypeEnvironment
-filterEnvironment f (TypeEnvironment ms) = TypeEnvironment $ filterEnvironment' f ms
+filterEnvironment f (TypeEnvironment ms p ts) = TypeEnvironment (filterEnvironment' f ms) p ts
   where
     filterEnvironment' :: (String -> Bool) -> [(String, EmperorType)] -> [(String, EmperorType)]
     filterEnvironment' _ [] = []
@@ -81,10 +106,18 @@ filterEnvironment f (TypeEnvironment ms) = TypeEnvironment $ filterEnvironment' 
         | otherwise = filterEnvironment' f' ms'
 
 instance ToJSON TypeEnvironment where
-    toJSON (TypeEnvironment ms) = toJSON ms
+    toJSON (TypeEnvironment ms p ts) = object [ "env" .= (uncurry KV <$> ms), "purity" .= p, "returns" .= ts]
+
+fromKV :: KV a b -> (a,b)
+fromKV kv = (key kv, value kv)
+
+data KV k v = KV { key :: k , value :: v }
+    deriving (Generic)
+
+instance (ToJSON k, ToJSON v) => ToJSON (KV k v)
+
+instance (FromJSON k, FromJSON v) => FromJSON (KV k v)
 
 instance FromJSON TypeEnvironment where
-    parseJSON (Array o) = do
-        ms <- parseJSON (Array o)
-        return $ TypeEnvironment ms
-    parseJSON _ = fail "Expected array object when parsing type environment"
+    parseJSON (Object v) = TypeEnvironment <$> ((fromKV <$>) <$> (v .: "env")) <*> v .: "purity" <*> v .: "returns"
+    parseJSON _ = fail "Expected object when parsing type environment"

--- a/Types/Results.hs
+++ b/Types/Results.hs
@@ -17,6 +17,7 @@ module Types.Results
     ( EmperorType(..)
     , TypeCheckResult(..)
     , TypeJudgementResult(..)
+    , getPurity
     , getTypeList
     , isValid
     , isValidAnd
@@ -95,8 +96,7 @@ data Purity
 
 -- | Class of types which describe type operation results
 class TypeOp a where
-    isValid :: a -> Bool
-    -- ^ Indicates whether a type operation has returned a valid result
+    isValid :: a -> Bool-- ^ Indicates whether a type operation has returned a valid result
 
 instance TypeOp TypeCheckResult where
     isValid Pass = True
@@ -118,6 +118,11 @@ isValidAnd t (Valid t')
 getTypeList :: EmperorType -> [EmperorType]
 getTypeList (EFunction _ t1 t2) = t1 : getTypeList t2
 getTypeList x = [x]
+
+-- | Return the purity of an emperor function type
+getPurity :: EmperorType -> Either String Purity
+getPurity (EFunction p _ _) = Right p
+getPurity t = Left $ "Cannot get purity of type " ++ show t
 
 instance ToJSON EmperorType where
     toJSON IntP = primitiveToJSON "int"

--- a/Types/SubTyping.hs
+++ b/Types/SubTyping.hs
@@ -48,7 +48,6 @@ instance SubTypable EmperorType where
     _ |- (SubType a b)
         | a == b = Pass
     _ |- (SubType _ Any) = Pass
-    _ |- (SubType Unit _) = Pass
     _ |- (SubType IntP RealP) = Pass
     e |- (SubType (EList a) (EList b)) = e |- a <: b
     e |- (SubType (ETuple as) (ETuple bs)) =

--- a/t.e
+++ b/t.e
@@ -2,12 +2,35 @@ module asdf
 
 import <std> (print)
 
-main :: string -> int
-main s:
-	int x = 1
+main :: @() -> int
+main:
+	for i <- [1, 2, 3]:
+		@print("i")
+	#
+
+
 	@print("x")
-	@print(s)
-    return x
+	if false:
+		@print("Something true")
+	#else:
+		@print("Something false")
+		// int i = 5;
+		while true:
+			// int i = 1;
+			@print("asdf")
+			// int x = @print("asdf")
+		#
+	#
+	int i <- 5;
+	while false:
+		// int x = @print("asdf")
+		// char c = 'x'
+		// c = @print("i")
+		// c = @print("i")
+		i = i - 1
+	#
+	// char c <- @print("i")
+	return 0
 #
 
 f :: int -> int -> int
@@ -15,7 +38,7 @@ f x y:
 	return x * y
 #
 
-voidFunc :: @string -> ()
-v s:
-	@print(s)
-#
+// voidFunc :: @string -> ()
+// v s:
+// 	@print(s)
+// #


### PR DESCRIPTION
### Problem description

`#include` and `#pragma GCC depends` directives caused errors when using gcc internally. 

### How this PR fixes the problem

The bad directives above are removed when necessary.

### Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

Logging output also added to the standalone compiler.
