### PR TITLE
Restrict allowed exports

### DIFF
--- a/CodeGenerator/Context.hs
+++ b/CodeGenerator/Context.hs
@@ -16,6 +16,7 @@ module CodeGenerator.Context
     ( GenerationContext
     , annotation
     , destFile
+    , exposedIdents
     , indent
     , isEntryPoint
     , makeContext
@@ -26,6 +27,7 @@ module CodeGenerator.Context
     ) where
 
 import qualified Args (Args, entryPoint, input, outputFile, annotateSource, toCOnly)
+import Parser.AST (Ident)
 
 data GenerationContext =
     GenerationContext
@@ -35,11 +37,20 @@ data GenerationContext =
         , indent :: Int
         , annotation :: Int
         , nativeCompile :: Bool
+        , exposedIdents :: Maybe [Ident]
         }
     deriving (Show)
 
 makeContext :: Args.Args -> GenerationContext
-makeContext args = GenerationContext { isEntryPoint = Args.entryPoint args, sourceFile = inputFile, indent = 0, destFile = outFile, annotation = Args.annotateSource args, nativeCompile = (not . Args.toCOnly) args }
+makeContext args = GenerationContext
+        { isEntryPoint = Args.entryPoint args
+        , sourceFile = inputFile
+        , indent = 0
+        , destFile = outFile
+        , annotation = Args.annotateSource args
+        , nativeCompile = (not . Args.toCOnly) args
+        , exposedIdents = Nothing
+        }
     where
         inputFile = if null $ Args.input args then "stdin" else Args.input args
         outFile = if Args.outputFile args == "-" then "stdout" else Args.outputFile args

--- a/Formatter/Formatter.hs
+++ b/Formatter/Formatter.hs
@@ -77,7 +77,8 @@ instance Format ImportLocation where
 
 -- | Module headers may be formatted with their docs and name
 instance Format ModuleHeader where
-    format ctx (Module i _) = "module " ++ format ctx i
+    format ctx (Module i Nothing _) = "module " ++ format ctx i
+    format ctx (Module i (Just is) _) = "module " ++ format ctx i ++ '(' : format ctx is ++ ")"
 
 -- | Module items may be formatted by their contents
 instance Format ModuleItem where

--- a/Parser/AST.hs
+++ b/Parser/AST.hs
@@ -46,7 +46,7 @@ data AST =
 
 -- | A single module header
 data ModuleHeader =
-    Module Ident AlexPosn
+    Module Ident (Maybe [Ident]) AlexPosn
     deriving (Show)
 
 -- | A single imported file
@@ -193,4 +193,7 @@ data Call =
 -- | Data-structure to represent an identifier
 data Ident =
     Ident String AlexPosn
-    deriving (Eq, Ord, Show)
+    deriving (Ord, Show)
+
+instance Eq Ident where
+    Ident i _ == Ident i' _ = i == i'

--- a/Parser/EmperorParser.y
+++ b/Parser/EmperorParser.y
@@ -96,9 +96,8 @@ import Parser.Position (GetPos, getPos)
     "class"             { TClass                p }
     "component"         { TComponent            p }
     "#"                 { TBlockSeparator       p }
-    "_"                 { TIDC                  p }
+    -- "_"                 { TIDC                  p }
     "return"            { TReturn               p }
---     EOL                 { TEoL                  p }
 
 %nonassoc PURE
 %nonassoc IMPURE
@@ -128,7 +127,9 @@ ast :: {AST}
 ast : moduleHeader usings moduleBody                 { AST $1 $2 $3 }
 
 moduleHeader :: {ModuleHeader}
-moduleHeader : "module" IDENT ";" { Module (Ident (identifierVal $2) (position $2)) (position $1) }
+moduleHeader : "module" IDENT ";"                   { Module (Ident (identifierVal $2) (position $2)) Nothing (position $1) }
+             | "module" IDENT "(" identList ")" ";" { Module (Ident (identifierVal $2) (position $2)) (Just $4) (position $1) }
+             | "module" IDENT "()" ";"              { Module (Ident (identifierVal $2) (position $2)) (Just []) (position $1) }
 
 -- docs :: {[DocLine]}
 -- docs : DOCLINE          { [ $1] }

--- a/Parser/Position.hs
+++ b/Parser/Position.hs
@@ -46,7 +46,7 @@ instance GetPos AST where
     getPos (AST _ _ _) = AlexPn 1 1 1
 
 instance GetPos ModuleHeader where
-    getPos (Module _ p) = p
+    getPos (Module _ _ p) = p
 
 instance GetPos Import where
     getPos (Import _ _ p) = p

--- a/Types/Imports/Imports.hs
+++ b/Types/Imports/Imports.hs
@@ -44,10 +44,15 @@ writeHeader f a = do
     Types.Imports.JsonIO.writeHeader h f
   where
     generateHeader :: TypeEnvironment -> AST -> Header
-    generateHeader g' (AST (Module i _) is _) = Header i (loc <$> is) g'
+    generateHeader g' (AST (Module i mis _) is _) = Header i (loc <$> is) g''
       where
         loc :: Import -> ImportLocation
         loc (Import l _ _) = l
+        g'' :: TypeEnvironment
+        g'' = case mis of
+            Nothing -> g'
+            Just is' -> let is'' = (\(Ident i' _) -> i') <$> is' in
+                filterEnvironment (`elem` is'') g'
 
 -- | Obtain the type environment created by the content of the module
 getLocalEnvironment :: AST -> TypeEnvironment


### PR DESCRIPTION
### Problem description

Output environments were not restricted.

### How this PR fixes the problem

The environment advertised in the generated header can now be restricted to a list specified at the module header.

Functions which are not exported are marked as `static` in the generated C header.

### Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

All exported identifiers are checked to ensure that they are present in the local environment.