### PR TITLE
Arch compat

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,231 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line. All default to true.
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      #
+      # Default: 4
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Replace tabs by spaces. This is disabled by default.
+  - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+      spaces: 4
+
+  # Remove trailing whitespace
+  # - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+columns: 120
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes

--- a/CodeGenerator/Results.hs
+++ b/CodeGenerator/Results.hs
@@ -19,9 +19,12 @@ data GenerationResult =
     GenerationResult [String] [String] [(String,Value)]
     deriving (Show)
 
+instance Semigroup GenerationResult where
+    (GenerationResult hs bs cs) <> (GenerationResult hs' bs' cs') = GenerationResult (hs <> hs') (bs <> bs') (cs <> cs')
+
 instance Monoid GenerationResult where
     mempty = GenerationResult [] [] []
-    mappend (GenerationResult hs bs cs) (GenerationResult hs' bs' cs') = GenerationResult (hs <> hs') (bs <> bs') (cs <> cs')
+    mappend  = (<>)
 
 makeHeaderLines :: [String] -> GenerationResult
 makeHeaderLines hs = GenerationResult hs [] []

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ all: build ## Build everything
 build: ./emperor ## Build everything, explicitly
 .PHONY: build
 
-./emperor: ./dist/build/emperor/emperor
-	@echo "[[ ! -f $@ ]] && ln -s $^ $@"
-	$(shell [[ ! -f $@ ]] && ln -s $^ $@)
+./emperor: ./dist-newstyle/build/x86_64-linux/ghc-8.6.5/emperor-0.1.0.0/x/emperor/build/emperor/emperor
+	@echo "[[ ! -f $@ ]] && ln -sf $^ $@"
+	$(shell [[ ! -f $@ ]] && ln -sf $^ $@)
 .DELETE_ON_ERROR: ./emperor
 
 ./dist/build/emperor/emperor: $(SOURCE_FILES)

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ build: ./emperor ## Build everything, explicitly
 	$(shell [[ ! -f $@ ]] && ln -sf $^ $@)
 .DELETE_ON_ERROR: ./emperor
 
-./dist/build/emperor/emperor: $(SOURCE_FILES)
-	cabal build $(CABALFLAGS)
+./dist-newstyle/build/x86_64-linux/ghc-8.6.5/emperor-0.1.0.0/x/emperor/build/emperor/emperor: $(SOURCE_FILES)
+	cabal new-build $(CABALFLAGS)
 
 ./Parser/EmperorLexer.hs: ./Parser/EmperorLexer.x ./Parser/EmperorLexer.hs.patch
 	$(LEXER_GENERATOR) $(LEXER_GENERATOR_FLAGS) $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ SOFT_LINK_COMMAND = [[ ! -f $@ ]] && ln -s $^ $@
 # Code up-keep commands
 LINTER := hlint
 LINTER_FLAGS := -s
-FORMATTER := hindent
-FORMATTER_FLAGS := --tab-size 4 --line-length 120
+FORMATTER := stylish-haskell
+FORMATTER_FLAGS := -i
 
 HEADER_INSTALL_DIRECTORY = $(shell emperor-setup --language-header-location)
 DEFAULT_HEADERS = $(shell find ./IncludedHeaders/ -type f | grep .h | sed "s/\.\/IncludedHeaders\///" | sed "s/^/$(shell emperor-setup --language-header-location | sed 's/\//\\\\\//g')/")

--- a/Parser/EmperorLexer.hs.patch
+++ b/Parser/EmperorLexer.hs.patch
@@ -6,17 +6,17 @@
  -- `move_pos' calculates the new position after traversing a given character,
 --- assuming the usual eight character tab stops.
 +-- assuming four character tab stops.
- 
- 
+
+
 +-- | Constructor to represent the position of a token in code.
 +-- Format: current line, current character on line, current total character over
 +-- all lines
  data AlexPosn = AlexPn !Int !Int !Int
          deriving (Eq,Show)
- 
+
 @@ -395,7 +398,7 @@
      }
- 
+
  -- Compile with -funbox-strict-fields for best results!
 -
 +-- | Function to run the generated lexer
@@ -26,159 +26,25 @@
 @@ -408,6 +411,7 @@
                          alex_scd = 0}) of Left msg -> Left msg
                                            Right ( _, a ) -> Right a
- 
+
 +-- | State information for an Alex lexer
  newtype Alex a = Alex { unAlex :: AlexState -> Either String (AlexState, a) }
- 
+
  instance Functor Alex where
 @@ -439,6 +443,7 @@
   = Alex $ \s -> case s{alex_pos=pos,alex_chr=c,alex_bytes=bs,alex_inp=inp__} of
                    state__@(AlexState{}) -> Right (state__, ())
- 
+
 +-- | Function to return an Alex error state
  alexError :: String -> Alex a
  alexError message = Alex $ const $ Left message
- 
+
 @@ -533,7 +538,7 @@
  -- For compatibility with previous versions of Alex, and because we can.
- 
+
  alex_tab_size :: Int
 -alex_tab_size = 8
 +alex_tab_size = 4
  alex_base :: AlexAddr
  alex_base = AlexA#
    "\xf8\xff\xff\xff\xdc\xff\xff\xff\xf6\xff\xff\xff\x76\x00\x00\x00\xf6\x00\x00\x00\x67\x01\x00\x00\x00\x00\x00\x00\xe7\x01\x00\x00\x00\x00\x00\x00\x58\x02\x00\x00\x00\x00\x00\x00\x99\x02\x00\x00\x00\x00\x00\x00\xda\x02\x00\x00\xda\x03\x00\x00\x9a\x03\x00\x00\x00\x00\x00\x00\x6a\x04\x00\x00\xe5\x04\x00\x00\xa5\x04\x00\x00\x00\x00\x00\x00\x9b\x05\x00\x00\xd6\xff\xff\xff\x06\x00\x00\x00\x91\x06\x00\x00\xe4\xff\xff\xff\x08\x00\x00\x00\x09\x00\x00\x00\x88\x07\x00\x00\x9e\x05\x00\x00\x9f\x05\x00\x00\x7c\x05\x00\x00\x90\x05\x00\x00\xdb\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x6f\x06\x00\x00\x66\x07\x00\x00\x58\x08\x00\x00\xa3\x08\x00\x00\x00\x00\x00\x00\xee\x08\x00\x00\x39\x09\x00\x00\x00\x00\x00\x00\x84\x09\x00\x00\xcf\x09\x00\x00\x1a\x0a\x00\x00\x65\x0a\x00\x00\xb0\x0a\x00\x00\xfb\x0a\x00\x00\x46\x0b\x00\x00\x91\x0b\x00\x00\xdc\x0b\x00\x00\x27\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x72\x0c\x00\x00\xbd\x0c\x00\x00\x08\x0d\x00\x00\x53\x0d\x00\x00\x9e\x0d\x00\x00\xe9\x0d\x00\x00\x34\x0e\x00\x00\x7f\x0e\x00\x00\xca\x0e\x00\x00\x15\x0f\x00\x00\x60\x0f\x00\x00\xab\x0f\x00\x00\xf6\x0f\x00\x00\x41\x10\x00\x00\x8c\x10\x00\x00\xd7\x10\x00\x00\x22\x11\x00\x00\x6d\x11\x00\x00\xb8\x11\x00\x00\x03\x12\x00\x00\x4e\x12\x00\x00\x99\x12\x00\x00\xe4\x12\x00\x00\x2f\x13\x00\x00\x7a\x13\x00\x00\xc5\x13\x00\x00\x10\x14\x00\x00\x5b\x14\x00\x00\xa6\x14\x00\x00\xf1\x14\x00\x00\x3c\x15\x00\x00\x87\x15\x00\x00\xd2\x15\x00\x00\x1d\x16\x00\x00\x68\x16\x00\x00\xb3\x16\x00\x00\xfe\x16\x00\x00\x49\x17\x00\x00\x94\x17\x00\x00\xdf\x17\x00\x00\x2a\x18\x00\x00\x75\x18\x00\x00\xc0\x18\x00\x00\x0b\x19\x00\x00\x56\x19\x00\x00\xa1\x19\x00\x00\xec\x19\x00\x00\x37\x1a\x00\x00\x82\x1a\x00\x00\xcd\x1a\x00\x00\x18\x1b\x00\x00\x63\x1b\x00\x00\xae\x1b\x00\x00\xf9\x1b\x00\x00\x44\x1c\x00\x00\x8f\x1c\x00\x00\xda\x1c\x00\x00\x25\x1d\x00\x00\x70\x1d\x00\x00\xbb\x1d\x00\x00\x06\x1e\x00\x00\x51\x1e\x00\x00\x9c\x1e\x00\x00\xe7\x1e\x00\x00\x32\x1f\x00\x00\x7d\x1f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xd7\xff\xff\xff\x00\x00\x00\x00\xed\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x9a\x04\x00\x00\x0d\x00\x00\x00\x00\x00\x00\x00\x9b\x04\x00\x00\x12\x00\x00\x00\x00\x00\x00\x00\x1c\x00\x00\x00\xc0\x06\x00\x00\x00\x00\x00\x00\xf9\xff\xff\xff\x29\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x68\x04\x00\x00\x00\x00\x00\x00\x83\x04\x00\x00\x00\x00\x00\x00\x2e\x04\x00\x00\x00\x00\x00\x00\x88\x04\x00\x00\x00\x00\x00\x00\x70\x06\x00\x00\x00\x00\x00\x00\x89\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"#
-@@ -1148,70 +1153,70 @@
-     a <= b = (a < b) || (a == b)
- 
- 
--alex_action_4 =  mkL LInteger 
--alex_action_5 =  mkL LBool 
--alex_action_6 =  mkL LReal 
--alex_action_7 =  mkL LChar 
--alex_action_8 =  mkL LString 
--alex_action_9 =  mkL LIntT 
--alex_action_10 =  mkL LBoolT 
--alex_action_11 =  mkL LRealT 
--alex_action_12 =  mkL LCharT 
--alex_action_13 =  mkL LUnit 
--alex_action_14 =  mkL LAnyT 
--alex_action_15 =  mkL LStringT 
--alex_action_16 =  mkL LIDC 
--alex_action_17 =  mkL LReturn 
--alex_action_18 =  mkL LIf 
--alex_action_19 =  mkL LElse 
--alex_action_20 =  mkL LWhile 
--alex_action_21 =  mkL LRepeat 
--alex_action_22 =  mkL LWith 
--alex_action_23 =  mkL LSwitch 
--alex_action_24 =  mkL LFor 
--alex_action_25 =  mkL LImport 
--alex_action_26 =  mkL LModule 
--alex_action_27 =  mkL LIsSubType 
--alex_action_28 =  mkL LIsImplementeBy 
--alex_action_29 =  mkL LIsType 
--alex_action_30 =  mkL LClass 
--alex_action_31 =  mkL LComponent 
--alex_action_32 =  mkL LIdent 
--alex_action_37 =  mkL LQueue 
--alex_action_38 =  mkL LGoesTo 
--alex_action_39 =  mkL LGets 
-+alex_action_4 =  mkL LInteger
-+alex_action_5 =  mkL LBool
-+alex_action_6 =  mkL LReal
-+alex_action_7 =  mkL LChar
-+alex_action_8 =  mkL LString
-+alex_action_9 =  mkL LIntT
-+alex_action_10 =  mkL LBoolT
-+alex_action_11 =  mkL LRealT
-+alex_action_12 =  mkL LCharT
-+alex_action_13 =  mkL LUnit
-+alex_action_14 =  mkL LAnyT
-+alex_action_15 =  mkL LStringT
-+alex_action_16 =  mkL LIDC
-+alex_action_17 =  mkL LReturn
-+alex_action_18 =  mkL LIf
-+alex_action_19 =  mkL LElse
-+alex_action_20 =  mkL LWhile
-+alex_action_21 =  mkL LRepeat
-+alex_action_22 =  mkL LWith
-+alex_action_23 =  mkL LSwitch
-+alex_action_24 =  mkL LFor
-+alex_action_25 =  mkL LImport
-+alex_action_26 =  mkL LModule
-+alex_action_27 =  mkL LIsSubType
-+alex_action_28 =  mkL LIsImplementeBy
-+alex_action_29 =  mkL LIsType
-+alex_action_30 =  mkL LClass
-+alex_action_31 =  mkL LComponent
-+alex_action_32 =  mkL LIdent
-+alex_action_37 =  mkL LQueue
-+alex_action_38 =  mkL LGoesTo
-+alex_action_39 =  mkL LGets
- alex_action_40 =  mkL LComma
--alex_action_41 =  mkL LLParenth 
--alex_action_42 =  mkL LRParenth 
--alex_action_43 =  mkL LLBracket 
--alex_action_44 =  mkL LRBracket 
--alex_action_45 =  mkL LLBrace 
--alex_action_46 =  mkL LRBrace 
--alex_action_47 =  mkL LImpure 
--alex_action_48 =  mkL LPartSeparator 
--alex_action_49 =  mkL LBlockSeparator 
--alex_action_50 =  mkL LColon 
--alex_action_51 =  mkL LPlus 
--alex_action_52 =  mkL LMinus 
--alex_action_53 =  mkL LDivide 
--alex_action_54 =  mkL LModulo 
--alex_action_55 =  mkL LTimes 
--alex_action_56 =  mkL LShiftLeft 
--alex_action_57 =  mkL LShiftRight 
--alex_action_58 =  mkL LShiftRightSameSign 
--alex_action_59 =  mkL LAndScrict 
--alex_action_60 =  mkL LAndLazy 
--alex_action_61 =  mkL LOrStrict 
--alex_action_62 =  mkL LOrLazy 
--alex_action_63 =  mkL LNot 
--alex_action_64 =  mkL LXor 
--alex_action_65 =  mkL LLessThan 
--alex_action_66 =  mkL LLessThanOrEqual 
--alex_action_67 =  mkL LGreaterThan 
--alex_action_68 =  mkL LGreaterThanOrEqual 
--alex_action_69 =  mkL LImplies 
--alex_action_70 =  mkL LEqual 
--alex_action_71 =  mkL LNotEqual 
-+alex_action_41 =  mkL LLParenth
-+alex_action_42 =  mkL LRParenth
-+alex_action_43 =  mkL LLBracket
-+alex_action_44 =  mkL LRBracket
-+alex_action_45 =  mkL LLBrace
-+alex_action_46 =  mkL LRBrace
-+alex_action_47 =  mkL LImpure
-+alex_action_48 =  mkL LPartSeparator
-+alex_action_49 =  mkL LBlockSeparator
-+alex_action_50 =  mkL LColon
-+alex_action_51 =  mkL LPlus
-+alex_action_52 =  mkL LMinus
-+alex_action_53 =  mkL LDivide
-+alex_action_54 =  mkL LModulo
-+alex_action_55 =  mkL LTimes
-+alex_action_56 =  mkL LShiftLeft
-+alex_action_57 =  mkL LShiftRight
-+alex_action_58 =  mkL LShiftRightSameSign
-+alex_action_59 =  mkL LAndScrict
-+alex_action_60 =  mkL LAndLazy
-+alex_action_61 =  mkL LOrStrict
-+alex_action_62 =  mkL LOrLazy
-+alex_action_63 =  mkL LNot
-+alex_action_64 =  mkL LXor
-+alex_action_65 =  mkL LLessThan
-+alex_action_66 =  mkL LLessThanOrEqual
-+alex_action_67 =  mkL LGreaterThan
-+alex_action_68 =  mkL LGreaterThanOrEqual
-+alex_action_69 =  mkL LImplies
-+alex_action_70 =  mkL LEqual
-+alex_action_71 =  mkL LNotEqual
- {-# LINE 1 "templates/GenericTemplate.hs" #-}
- {-# LINE 1 "templates/GenericTemplate.hs" #-}
- {-# LINE 1 "<built-in>" #-}

--- a/Types/Environment.hs
+++ b/Types/Environment.hs
@@ -36,11 +36,14 @@ data TypeEnvironment =
     TypeEnvironment [(String, EmperorType)] Purity [EmperorType]
     deriving (Eq, Show)
 
-instance Monoid TypeEnvironment where
-    mempty = newTypeEnvironment
-    mappend (TypeEnvironment g p ts) (TypeEnvironment g' p' ts') = TypeEnvironment (g ++ g') p'' (ts ++ ts')
+instance Semigroup TypeEnvironment where
+    (TypeEnvironment g p ts) <> (TypeEnvironment g' p' ts') = TypeEnvironment (g ++ g') p'' (ts ++ ts')
         where
             p'' = if p == Pure && p' == Pure then Pure else Impure
+
+instance Monoid TypeEnvironment where
+    mempty = newTypeEnvironment
+    mappend = (<>)
 
 -- | Creates a fresh type-environment
 newTypeEnvironment :: TypeEnvironment

--- a/emperor.cabal
+++ b/emperor.cabal
@@ -2,91 +2,110 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 -- The name of the package.
-name:                emperor
+name:               emperor
 
 -- The package version.  See the Haskell package versioning policy (PVP)
 -- for standards guiding when and how versions should be incremented.
 -- https://wiki.haskell.org/Package_versioning_policy
--- PVP summary:      +-+------- breaking API changes
---                   | | +----- non-breaking API additions
---                   | | | +--- code changes with no API change
-version:             0.1.0.0
+-- PVP summary:     +-+------- breaking API changes
+--                  | | +----- non-breaking API additions
+--                  | | | +--- code changes with no API change
+version:            0.1.0.0
 
 -- A short (one-line) description of the package.
-synopsis:            Emperor compiler
+synopsis:           Emperor compiler
 
 -- A longer description of the package.
-description:         Compiler for the emperor language
+description:        Compiler for the emperor language
 
 -- URL for the project homepage or repository.
-homepage:            emperor-lang.github.io
+homepage:           emperor-lang.github.io
 
 -- The license under which the package is released.
-license:             GPL-3
+license:            GPL-3
 
 -- The file containing the license text.
-license-file:        LICENSE
+license-file:       LICENSE
 
 -- The package author(s).
-author:              Edward Jones
+author:             Edward Jones
 
 -- An email address to which users can send suggestions, bug reports, and
 -- patches.
-maintainer:          edjones98@gmail.com
+maintainer:         edjones98@gmail.com
 
 -- A copyright notice.
 -- copyright:
 
-category:            Language
+category:           Language
 
-build-type:          Simple
+build-type:         Simple
 
 -- Extra files to be distributed with the package, such as examples or a
 -- README.
-extra-source-files:  ChangeLog.md, README.md, Makefile, LICENSE, emperor.json
+extra-source-files: ChangeLog.md, ./docs/README.md, Makefile, LICENSE, emperor.json
 
 -- Constraint on the version of Cabal needed to build this package.
-cabal-version:       >=1.10
+cabal-version:      >=1.10
 
 source-repository head
-  type:               git
-  location:           https://github.com/emperor-lang/emperor
-  branch:             master
+    type:           git
+    location:       https://github.com/emperor-lang/emperor
+    branch:         master
 
 executable emperor
-  -- .hs or .lhs file containing the Main module.
-  main-is:             Main.hs
+    -- .hs or .lhs file containing the Main module.
+    main-is:        Main.hs
 
-  -- Compiler flags
-  ghc-options:         -Wall -Wextra -Werror -O2
+    -- Compiler flags
+    ghc-options:    -Wall -Wextra -Werror -O2
 
-  -- Directories containing source files.
-  hs-source-dirs:      .
+    -- Directories containing source files.
+    hs-source-dirs: .
 
-  -- Modules included in this executable, other than Main.
-  -- other-modules:
+    -- Modules included in this executable, other than Main.
+    other-modules:   Args
+                    , CodeGenerator.Context
+                    , CodeGenerator.Generate
+                    , CodeGenerator.Position
+                    , CodeGenerator.Results
+                    , CodeGenerator.ToC
+                    , Formatter.Formatter
+                    , Logger.Logger
+                    , Optimiser.Optimise
+                    , Parser.AST
+                    , Parser.EmperorLexer
+                    , Parser.EmperorParser
+                    , Parser.EmperorParserWrapper
+                    , Parser.Position
+                    , StandaloneCompiler.Compile
+                    , Types.Checker
+                    , Types.Environment
+                    , Types.Imports.Imports
+                    , Types.Imports.JsonIO
+                    , Types.Judger
+                    , Types.PreludeTypes
+                    , Types.Results
+                    , Types.SubTyping
+                    , Types.Types
 
-  -- LANGUAGE extensions used by modules in this package.
-  -- other-extensions:
+    -- LANGUAGE extensions used by modules in this package.
+    -- other-extensions:
 
-  -- Other library packages from which modules are imported.
-  build-depends:       aeson >=1.2 && <1.3,
-                       ansi-terminal >= 0.9.1 && < 0.10,
-                       array >= 0.5 && < 0.6,
-                       aeson >= 1.2 && < 1.3,
-                       base >=4.9 && <4.10,
-                       bytestring >= 0.10 && < 0.11,
-                       containers >= 0.5 && < 0.6,
-                       directory >= 1.3 && < 1.4,
-                       process >=1.4 && < 1.5,
-                       text >=1.2 && <1.3,
-                       unordered-containers >=0.2 && <0.3,
-                       vector >=0.12 && <0.13,
-                       zlib >= 0.6 && <0.7
+    -- Other library packages from which modules are imported.
+    build-depends:  aeson >=1.4 && <1.5
+                    , ansi-terminal >= 0.9 && < 0.10
+                    , array >= 0.5 && < 0.6
+                    , base >=4.12 && <4.13
+                    , bytestring >= 0.10 && < 0.11
+                    , containers >= 0.6 && < 0.7
+                    , directory >= 1.3 && < 1.4
+                    , process >=1.6 && < 1.7
+                    , text >=1.2 && <1.3
+                    , unordered-containers >=0.2 && <0.3
+                    , vector >=0.12 && <0.13
+                    , zlib >= 0.6 && <0.7
 
-  -- Directories containing source files.
-  -- hs-source-dirs:
-
-  -- Base language which the package is written in.
-  default-language:    Haskell2010
+    -- Base language which the package is written in.
+    default-language:     Haskell2010
 


### PR DESCRIPTION
### Problem description

Incompatible with new installation of Arch Linux.

### How this PR fixes the problem

This adds compatibility changes and updates packages to newer versions.

### Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

Also changes the linter used since apparently this was an old one. (`hindent -> stylish-haskell`)
